### PR TITLE
Improvement of 'values_map' property in class 'ReqIFDataTypeDefinitionEnumeration'

### DIFF
--- a/reqif/models/reqif_data_type.py
+++ b/reqif/models/reqif_data_type.py
@@ -146,7 +146,8 @@ class ReqIFDataTypeDefinitionEnumeration:  # pylint: disable=too-many-instance-a
         self.values_map: Dict[str, str] = {}
         if values is not None:
             for value in values:
-                self.values_map[value.identifier] = value.key
+                # adapted by em AG
+                self.values_map[value.identifier] = value
         self.is_self_closed: bool = is_self_closed
 
     @staticmethod

--- a/reqif/models/reqif_data_type.py
+++ b/reqif/models/reqif_data_type.py
@@ -143,7 +143,7 @@ class ReqIFDataTypeDefinitionEnumeration:  # pylint: disable=too-many-instance-a
         self.long_name: Optional[str] = long_name
         self.multi_valued: Optional[bool] = multi_valued
         self.values: Optional[List[ReqIFEnumValue]] = values
-        self.values_map: Dict[str, str] = {}
+        self.values_map: Dict[str, ReqIFEnumValue] = {}
         if values is not None:
             for value in values:
                 self.values_map[value.identifier] = value

--- a/reqif/models/reqif_data_type.py
+++ b/reqif/models/reqif_data_type.py
@@ -146,7 +146,6 @@ class ReqIFDataTypeDefinitionEnumeration:  # pylint: disable=too-many-instance-a
         self.values_map: Dict[str, str] = {}
         if values is not None:
             for value in values:
-                # adapted by em AG
                 self.values_map[value.identifier] = value
         self.is_self_closed: bool = is_self_closed
 

--- a/reqif/models/reqif_relation_group_type.py
+++ b/reqif/models/reqif_relation_group_type.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+
+class ReqIFRelationGroupType:
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        identifier: str,
+        description: Optional[str] = None,
+        last_change: Optional[str] = None,
+        long_name: Optional[str] = None,
+        is_self_closed: bool = True,
+    ):
+        self.identifier: str = identifier
+        self.description: Optional[str] = description
+        self.last_change: Optional[str] = last_change
+        self.long_name: Optional[str] = long_name
+        self.is_self_closed: bool = is_self_closed

--- a/reqif/parser.py
+++ b/reqif/parser.py
@@ -19,6 +19,7 @@ from reqif.models.reqif_reqif_header import ReqIFReqIFHeader
 from reqif.models.reqif_spec_object import ReqIFSpecObject
 from reqif.models.reqif_spec_object_type import ReqIFSpecObjectType
 from reqif.models.reqif_spec_relation import ReqIFSpecRelation
+from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
 from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
 from reqif.models.reqif_specification import (
     ReqIFSpecification,
@@ -43,6 +44,9 @@ from reqif.parsers.spec_types.spec_relation_type_parser import (
 )
 from reqif.parsers.spec_types.specification_type_parser import (
     SpecificationTypeParser,
+)
+from reqif.parsers.spec_types.relation_group_type_parser import (
+    RelationGroupTypeParser,
 )
 from reqif.parsers.specification_parser import (
     ReqIFSpecificationParser,
@@ -234,6 +238,7 @@ class ReqIFParser:
                     ReqIFSpecObjectType,
                     ReqIFSpecRelationType,
                     ReqIFSpecificationType,
+                    ReqIFRelationGroupType,
                 ]
                 if xml_spec_object_type_xml.tag == "SPEC-OBJECT-TYPE":
                     spec_type = SpecObjectTypeParser.parse(
@@ -247,6 +252,10 @@ class ReqIFParser:
                     spec_type = SpecificationTypeParser.parse(
                         xml_spec_object_type_xml
                     )
+                elif xml_spec_object_type_xml.tag == "RELATION-GROUP-TYPE":
+                    spec_type = RelationGroupTypeParser.parse(
+                        xml_spec_object_type_xml
+                    )                    
                 else:
                     raise NotImplementedError(
                         xml_spec_object_type_xml
@@ -301,7 +310,8 @@ class ReqIFParser:
         if xml_spec_relation_groups is not None:
             spec_relation_groups = []
             if len(xml_spec_relation_groups) != 0:
-                raise NotImplementedError(xml_spec_relation_groups) from None
+                spec_relation_groups = []
+                #raise NotImplementedError(xml_spec_relation_groups) from None
 
         lookup = ReqIFObjectLookup(
             data_types_lookup=data_types_lookup,

--- a/reqif/parsers/spec_types/relation_group_type_parser.py
+++ b/reqif/parsers/spec_types/relation_group_type_parser.py
@@ -1,0 +1,59 @@
+import html
+from typing import Optional
+
+from reqif.helpers.lxml import lxml_is_self_closed_tag
+from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
+
+
+class RelationGroupTypeParser:
+    @staticmethod
+    def parse(xml_spec_relation_type_xml) -> ReqIFRelationGroupType:
+        assert (
+            xml_spec_relation_type_xml.tag == "RELATION-GROUP-TYPE"
+        ), f"{xml_spec_relation_type_xml}"
+        is_self_closed = lxml_is_self_closed_tag(xml_spec_relation_type_xml)
+
+        xml_attributes = xml_spec_relation_type_xml.attrib
+        # Expecting all tools to implement IDENTIFIER and LONG-NAME.
+        try:
+            identifier = xml_attributes["IDENTIFIER"]
+        except Exception:
+            raise NotImplementedError(xml_attributes) from None
+        
+        long_name: Optional[str] = (
+            xml_attributes["LONG-NAME"] if "LONG-NAME" in xml_attributes else None
+        )
+
+        description: Optional[str] = (
+            xml_attributes["DESC"] if "DESC" in xml_attributes else None
+        )
+        last_change: Optional[str] = (
+            xml_attributes["LAST-CHANGE"]
+            if "LAST-CHANGE" in xml_attributes
+            else None
+        )
+
+        return ReqIFRelationGroupType(
+            is_self_closed=is_self_closed,
+            description=description,
+            identifier=identifier,
+            last_change=last_change,
+            long_name=long_name,
+        )
+
+    @staticmethod
+    def unparse(spec_relation_type: ReqIFRelationGroupType):
+        output = "        <SPEC-RELATION-TYPE"
+        if spec_relation_type.description is not None:
+            output += f' DESC="{html.escape(spec_relation_type.description)}"'
+        output += f' IDENTIFIER="{spec_relation_type.identifier}"'
+        if spec_relation_type.last_change is not None:
+            output += f' LAST-CHANGE="{spec_relation_type.last_change}"'
+        if spec_relation_type.long_name is not None:
+            output += f' LONG-NAME="{spec_relation_type.long_name}"'
+        if spec_relation_type.is_self_closed:
+            output += "/>\n"
+        else:
+            output += ">\n"
+            output += "        </SPEC-RELATION-TYPE>\n"
+        return output


### PR DESCRIPTION
To get easier the values of an enumeration data type by the identifier, I changed the values_map property from <IDENTIFIER>: <VALUE_KEY> to <IDENTIFIER>: <VALUE>.
So I have direct acces to the value object by the identifier.