### PR TITLE
Pep 328 relative imports for local packages

### DIFF
--- a/reqif/cli/main.py
+++ b/reqif/cli/main.py
@@ -9,13 +9,13 @@ try:
         raise FileNotFoundError(ROOT_PATH)
     sys.path.append(ROOT_PATH)
 
-    from reqif.cli.cli_arg_parser import create_reqif_args_parser
-    from reqif.commands.anonymize.anonymize import AnonymizeCommand
-    from reqif.commands.dump.dump import DumpCommand
-    from reqif.commands.format.format import FormatCommand
-    from reqif.commands.passthrough.passthrough import PassthroughCommand
-    from reqif.commands.validate.validate import ValidateCommand
-    from reqif.commands.version.version_command import VersionCommand
+    from .cli_arg_parser import create_reqif_args_parser
+    from ..commands.anonymize.anonymize import AnonymizeCommand
+    from ..commands.dump.dump import DumpCommand
+    from ..commands.format.format import FormatCommand
+    from ..commands.passthrough.passthrough import PassthroughCommand
+    from ..commands.validate.validate import ValidateCommand
+    from ..commands.version.version_command import VersionCommand
 
 except FileNotFoundError:
     print("error: could not locate reqif's root folder.")  # noqa: T201

--- a/reqif/commands/anonymize/anonymize.py
+++ b/reqif/commands/anonymize/anonymize.py
@@ -7,12 +7,12 @@ from typing import List
 from lxml import etree
 from lxml.etree import tostring
 
-from reqif.cli.cli_arg_parser import AnonimizeCommandConfig
-from reqif.helpers.lxml import lxml_stringify_namespaced_children
-from reqif.models.error_handling import ReqIFXMLParsingError
-from reqif.models.reqif_spec_object import ReqIFSpecObject, SpecObjectAttribute
-from reqif.models.reqif_specification import ReqIFSpecification
-from reqif.models.reqif_types import SpecObjectAttributeType
+from ...cli.cli_arg_parser import AnonimizeCommandConfig
+from ...helpers.lxml import lxml_stringify_namespaced_children
+from ...models.error_handling import ReqIFXMLParsingError
+from ...models.reqif_spec_object import ReqIFSpecObject, SpecObjectAttribute
+from ...models.reqif_specification import ReqIFSpecification
+from ...models.reqif_types import SpecObjectAttributeType
 
 ANONYMIZED = "Anonymized"
 

--- a/reqif/commands/dump/dump.py
+++ b/reqif/commands/dump/dump.py
@@ -1,7 +1,7 @@
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
-from reqif.cli.cli_arg_parser import DumpCommandConfig
-from reqif.parser import ReqIFParser
+from ...cli.cli_arg_parser import DumpCommandConfig
+from ...parser import ReqIFParser
 
 
 class DumpCommand:

--- a/reqif/commands/format/format.py
+++ b/reqif/commands/format/format.py
@@ -1,6 +1,6 @@
 from lxml import etree
 
-from reqif.cli.cli_arg_parser import FormatCommandConfig
+from ...cli.cli_arg_parser import FormatCommandConfig
 
 
 class FormatCommand:

--- a/reqif/commands/passthrough/passthrough.py
+++ b/reqif/commands/passthrough/passthrough.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-from reqif.cli.cli_arg_parser import PassthroughCommandConfig
-from reqif.parser import ReqIFParser
-from reqif.unparser import ReqIFUnparser
+from ...cli.cli_arg_parser import PassthroughCommandConfig
+from ...parser import ReqIFParser
+from ...unparser import ReqIFUnparser
 
 
 class PassthroughCommand:

--- a/reqif/commands/validate/validate.py
+++ b/reqif/commands/validate/validate.py
@@ -2,8 +2,8 @@ import os
 import sys
 from typing import List
 
-from reqif.cli.cli_arg_parser import ValidateCommandConfig
-from reqif.models.error_handling import (
+from ...cli.cli_arg_parser import ValidateCommandConfig
+from ...models.error_handling import (
     ReqIFGeneralSemanticError,
     ReqIFSchemaError,
     ReqIFSemanticError,
@@ -11,10 +11,10 @@ from reqif.models.error_handling import (
     ReqIFSpecRelationMissingSpecObjectException,
     ReqIFXMLParsingError,
 )
-from reqif.models.reqif_spec_relation import ReqIFSpecRelation
-from reqif.models.reqif_specification import ReqIFSpecification
-from reqif.parser import ReqIFParser
-from reqif.reqif_bundle import ReqIFBundle
+from ...models.reqif_spec_relation import ReqIFSpecRelation
+from ...models.reqif_specification import ReqIFSpecification
+from ...parser import ReqIFParser
+from ...reqif_bundle import ReqIFBundle
 
 
 class ReqIFErrorBundle:

--- a/reqif/commands/version/version_command.py
+++ b/reqif/commands/version/version_command.py
@@ -1,4 +1,4 @@
-from reqif import __version__
+from . import __version__
 
 
 class VersionCommand:

--- a/reqif/models/error_handling.py
+++ b/reqif/models/error_handling.py
@@ -1,4 +1,4 @@
-from reqif.helpers.lxml import lxml_dump_node
+from ..helpers.lxml import lxml_dump_node
 
 
 class ReqIFXMLParsingError(Exception):

--- a/reqif/models/reqif_core_content.py
+++ b/reqif/models/reqif_core_content.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_req_if_content import ReqIFReqIFContent
+from ..helpers.debug import auto_described
+from .reqif_req_if_content import ReqIFReqIFContent
 
 
 @auto_described

--- a/reqif/models/reqif_data_type.py
+++ b/reqif/models/reqif_data_type.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-from reqif.helpers.debug import auto_described
+from ..helpers.debug import auto_described
 
 
 @auto_described

--- a/reqif/models/reqif_namespace_info.py
+++ b/reqif/models/reqif_namespace_info.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from reqif.helpers.debug import auto_described
+from ..helpers.debug import auto_described
 
 
 @auto_described

--- a/reqif/models/reqif_req_if_content.py
+++ b/reqif/models/reqif_req_if_content.py
@@ -1,14 +1,14 @@
 from typing import List, Optional, Union
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_relation_group import ReqIFRelationGroup
-from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
-from reqif.models.reqif_spec_object import ReqIFSpecObject
-from reqif.models.reqif_spec_object_type import ReqIFSpecObjectType
-from reqif.models.reqif_spec_relation import ReqIFSpecRelation
-from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
-from reqif.models.reqif_specification import ReqIFSpecification
-from reqif.models.reqif_specification_type import ReqIFSpecificationType
+from ..helpers.debug import auto_described
+from .reqif_relation_group import ReqIFRelationGroup
+from .reqif_relation_group_type import ReqIFRelationGroupType
+from .reqif_spec_object import ReqIFSpecObject
+from .reqif_spec_object_type import ReqIFSpecObjectType
+from .reqif_spec_relation import ReqIFSpecRelation
+from .reqif_spec_relation_type import ReqIFSpecRelationType
+from .reqif_specification import ReqIFSpecification
+from .reqif_specification_type import ReqIFSpecificationType
 
 
 @auto_described

--- a/reqif/models/reqif_reqif_header.py
+++ b/reqif/models/reqif_reqif_header.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
 
-from reqif.helpers.debug import auto_described
+from ..helpers.debug import auto_described
 
 
 # Sometimes, the ReqIFs have empty tags. Example:

--- a/reqif/models/reqif_spec_hierarchy.py
+++ b/reqif/models/reqif_spec_hierarchy.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional
 
-from reqif.helpers.debug import auto_described
+from ..helpers.debug import auto_described
 
 
 @auto_described

--- a/reqif/models/reqif_spec_object.py
+++ b/reqif/models/reqif_spec_object.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_types import SpecObjectAttributeType
+from ..helpers.debug import auto_described
+from .reqif_types import SpecObjectAttributeType
 
 
 @auto_described

--- a/reqif/models/reqif_spec_object_type.py
+++ b/reqif/models/reqif_spec_object_type.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_types import SpecObjectAttributeType
+from ..helpers.debug import auto_described
+from .reqif_types import SpecObjectAttributeType
 
 
 class DefaultValueEmptySelfClosedTag:

--- a/reqif/models/reqif_spec_relation.py
+++ b/reqif/models/reqif_spec_relation.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_spec_object import SpecObjectAttribute
+from ..helpers.debug import auto_described
+from .reqif_spec_object import SpecObjectAttribute
 
 
 @auto_described

--- a/reqif/models/reqif_spec_relation_type.py
+++ b/reqif/models/reqif_spec_relation_type.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from reqif.models.reqif_spec_object_type import SpecAttributeDefinition
+from .reqif_spec_object_type import SpecAttributeDefinition
 
 
 class ReqIFSpecRelationType:

--- a/reqif/models/reqif_specification.py
+++ b/reqif/models/reqif_specification.py
@@ -1,10 +1,10 @@
 from typing import Any, List, Optional
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_spec_hierarchy import (
+from ..helpers.debug import auto_described
+from .reqif_spec_hierarchy import (
     ReqIFSpecHierarchy,
 )
-from reqif.models.reqif_spec_object import SpecObjectAttribute
+from .reqif_spec_object import SpecObjectAttribute
 
 
 @auto_described

--- a/reqif/models/reqif_specification_type.py
+++ b/reqif/models/reqif_specification_type.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_spec_object_type import SpecAttributeDefinition
+from ..helpers.debug import auto_described
+from .reqif_spec_object_type import SpecAttributeDefinition
 
 
 @auto_described

--- a/reqif/object_lookup.py
+++ b/reqif/object_lookup.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List
 
-from reqif.helpers.debug import auto_described
-from reqif.models.reqif_spec_object import ReqIFSpecObject
+from .helpers.debug import auto_described
+from .models.reqif_spec_object import ReqIFSpecObject
 
 
 @auto_described

--- a/reqif/parser.py
+++ b/reqif/parser.py
@@ -6,53 +6,53 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from lxml import etree
 from lxml.etree import DocInfo
 
-from reqif.helpers.lxml import lxml_strip_namespace_from_xml
-from reqif.models.error_handling import (
+from .helpers.lxml import lxml_strip_namespace_from_xml
+from .models.error_handling import (
     ReqIFMissingTagException,
     ReqIFSchemaError,
     ReqIFXMLParsingError,
 )
-from reqif.models.reqif_core_content import ReqIFCoreContent
-from reqif.models.reqif_namespace_info import ReqIFNamespaceInfo
-from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
-from reqif.models.reqif_req_if_content import ReqIFReqIFContent
-from reqif.models.reqif_reqif_header import ReqIFReqIFHeader
-from reqif.models.reqif_spec_object import ReqIFSpecObject
-from reqif.models.reqif_spec_object_type import ReqIFSpecObjectType
-from reqif.models.reqif_spec_relation import ReqIFSpecRelation
-from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
-from reqif.models.reqif_specification import (
+from .models.reqif_core_content import ReqIFCoreContent
+from .models.reqif_namespace_info import ReqIFNamespaceInfo
+from .models.reqif_relation_group_type import ReqIFRelationGroupType
+from .models.reqif_req_if_content import ReqIFReqIFContent
+from .models.reqif_reqif_header import ReqIFReqIFHeader
+from .models.reqif_spec_object import ReqIFSpecObject
+from .models.reqif_spec_object_type import ReqIFSpecObjectType
+from .models.reqif_spec_relation import ReqIFSpecRelation
+from .models.reqif_spec_relation_type import ReqIFSpecRelationType
+from .models.reqif_specification import (
     ReqIFSpecification,
 )
-from reqif.models.reqif_specification_type import ReqIFSpecificationType
-from reqif.object_lookup import ReqIFObjectLookup
-from reqif.parsers.data_type_parser import (
+from .models.reqif_specification_type import ReqIFSpecificationType
+from .object_lookup import ReqIFObjectLookup
+from .parsers.data_type_parser import (
     DataTypeParser,
 )
-from reqif.parsers.header_parser import ReqIFHeaderParser
-from reqif.parsers.relation_group_parser import ReqIFRelationGroupParser
-from reqif.parsers.spec_object_parser import (
+from .parsers.header_parser import ReqIFHeaderParser
+from .parsers.relation_group_parser import ReqIFRelationGroupParser
+from .parsers.spec_object_parser import (
     SpecObjectParser,
 )
-from reqif.parsers.spec_relation_parser import (
+from .parsers.spec_relation_parser import (
     SpecRelationParser,
 )
-from reqif.parsers.spec_types.relation_group_type_parser import (
+from .parsers.spec_types.relation_group_type_parser import (
     RelationGroupTypeParser,
 )
-from reqif.parsers.spec_types.spec_object_type_parser import (
+from .parsers.spec_types.spec_object_type_parser import (
     SpecObjectTypeParser,
 )
-from reqif.parsers.spec_types.spec_relation_type_parser import (
+from .parsers.spec_types.spec_relation_type_parser import (
     SpecRelationTypeParser,
 )
-from reqif.parsers.spec_types.specification_type_parser import (
+from .parsers.spec_types.specification_type_parser import (
     SpecificationTypeParser,
 )
-from reqif.parsers.specification_parser import (
+from .parsers.specification_parser import (
     ReqIFSpecificationParser,
 )
-from reqif.reqif_bundle import ReqIFBundle
+from .reqif_bundle import ReqIFBundle
 
 
 class ReqIFParser:

--- a/reqif/parsers/attribute_definition_parser.py
+++ b/reqif/parsers/attribute_definition_parser.py
@@ -1,15 +1,15 @@
 from typing import List, Optional, Union
 
-from reqif.helpers.lxml import (
+from ..helpers.lxml import (
     lxml_escape_for_html,
     lxml_is_self_closed_tag,
     lxml_stringify_namespaced_children,
 )
-from reqif.models.reqif_spec_object_type import (
+from ..models.reqif_spec_object_type import (
     DefaultValueEmptySelfClosedTag,
     SpecAttributeDefinition,
 )
-from reqif.models.reqif_types import SpecObjectAttributeType
+from ..models.reqif_types import SpecObjectAttributeType
 
 
 class AttributeDefinitionParser:

--- a/reqif/parsers/attribute_value_parser.py
+++ b/reqif/parsers/attribute_value_parser.py
@@ -3,14 +3,14 @@ from typing import Any, List, Optional
 
 from lxml import etree
 
-from reqif.helpers.lxml import (
+from ..helpers.lxml import (
     lxml_convert_children_from_reqif_ns_xhtml_string,
     lxml_stringify_children,
     lxml_stringify_namespaced_children,
 )
-from reqif.helpers.string.xhtml_indent import reqif_unindent_xhtml_string
-from reqif.models.reqif_spec_object import SpecObjectAttribute
-from reqif.models.reqif_types import SpecObjectAttributeType
+from ..helpers.string.xhtml_indent import reqif_unindent_xhtml_string
+from ..models.reqif_spec_object import SpecObjectAttribute
+from ..models.reqif_types import SpecObjectAttributeType
 
 ATTRIBUTE_STRING_TEMPLATE = """\
             <ATTRIBUTE-VALUE-STRING THE-VALUE="{value}">

--- a/reqif/parsers/data_type_parser.py
+++ b/reqif/parsers/data_type_parser.py
@@ -2,8 +2,8 @@ from typing import List, Optional, Union
 
 from lxml import etree
 
-from reqif.helpers.lxml import lxml_escape_for_html, lxml_is_self_closed_tag
-from reqif.models.reqif_data_type import (
+from ..helpers.lxml import lxml_escape_for_html, lxml_is_self_closed_tag
+from ..models.reqif_data_type import (
     ReqIFDataTypeDefinitionBoolean,
     ReqIFDataTypeDefinitionDateIdentifier,
     ReqIFDataTypeDefinitionEnumeration,

--- a/reqif/parsers/header_parser.py
+++ b/reqif/parsers/header_parser.py
@@ -1,7 +1,7 @@
 from typing import Union
 
-from reqif.helpers.lxml import lxml_escape_title
-from reqif.models.reqif_reqif_header import EmptyTag, ReqIFReqIFHeader
+from ..helpers.lxml import lxml_escape_title
+from ..models.reqif_reqif_header import EmptyTag, ReqIFReqIFHeader
 
 
 class ReqIFHeaderParser:

--- a/reqif/parsers/relation_group_parser.py
+++ b/reqif/parsers/relation_group_parser.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from reqif.models.reqif_relation_group import ReqIFRelationGroup
+from ..models.reqif_relation_group import ReqIFRelationGroup
 
 
 class ReqIFRelationGroupParser:

--- a/reqif/parsers/spec_hierarchy_parser.py
+++ b/reqif/parsers/spec_hierarchy_parser.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
-from reqif.helpers.lxml import lxml_is_self_closed_tag
-from reqif.models.reqif_spec_hierarchy import (
+from ..helpers.lxml import lxml_is_self_closed_tag
+from ..models.reqif_spec_hierarchy import (
     ReqIFSpecHierarchy,
 )
 

--- a/reqif/parsers/spec_object_parser.py
+++ b/reqif/parsers/spec_object_parser.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
 
-from reqif.models.reqif_spec_object import (
+from ..models.reqif_spec_object import (
     ReqIFSpecObject,
     SpecObjectAttribute,
 )
-from reqif.parsers.attribute_value_parser import AttributeValueParser
+from .attribute_value_parser import AttributeValueParser
 
 
 class SpecObjectParser:

--- a/reqif/parsers/spec_relation_parser.py
+++ b/reqif/parsers/spec_relation_parser.py
@@ -1,12 +1,12 @@
 from typing import List, Optional
 
-from reqif.models.error_handling import ReqIFMissingTagException
-from reqif.models.reqif_spec_object import SpecObjectAttribute
-from reqif.models.reqif_spec_relation import (
+from ..models.error_handling import ReqIFMissingTagException
+from ..models.reqif_spec_object import SpecObjectAttribute
+from ..models.reqif_spec_relation import (
     ReqIFSpecRelation,
 )
-from reqif.models.reqif_types import SpecObjectAttributeType
-from reqif.parsers.attribute_value_parser import AttributeValueParser
+from ..models.reqif_types import SpecObjectAttributeType
+from ..parsers.attribute_value_parser import AttributeValueParser
 
 
 class SpecRelationParser:

--- a/reqif/parsers/spec_types/relation_group_type_parser.py
+++ b/reqif/parsers/spec_types/relation_group_type_parser.py
@@ -1,8 +1,8 @@
 import html
 from typing import Optional
 
-from reqif.helpers.lxml import lxml_is_self_closed_tag
-from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
+from ...helpers.lxml import lxml_is_self_closed_tag
+from ...models.reqif_relation_group_type import ReqIFRelationGroupType
 
 
 class RelationGroupTypeParser:

--- a/reqif/parsers/spec_types/spec_object_type_parser.py
+++ b/reqif/parsers/spec_types/spec_object_type_parser.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from reqif.helpers.lxml import lxml_escape_for_html
-from reqif.models.reqif_spec_object_type import (
+from ...helpers.lxml import lxml_escape_for_html
+from ...models.reqif_spec_object_type import (
     ReqIFSpecObjectType,
 )
-from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
+from ...parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
 class SpecObjectTypeParser:

--- a/reqif/parsers/spec_types/spec_relation_type_parser.py
+++ b/reqif/parsers/spec_types/spec_relation_type_parser.py
@@ -1,9 +1,9 @@
 import html
 from typing import Optional
 
-from reqif.helpers.lxml import lxml_is_self_closed_tag
-from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
-from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
+from ...helpers.lxml import lxml_is_self_closed_tag
+from ...models.reqif_spec_relation_type import ReqIFSpecRelationType
+from ..attribute_definition_parser import AttributeDefinitionParser
 
 
 class SpecRelationTypeParser:

--- a/reqif/parsers/spec_types/specification_type_parser.py
+++ b/reqif/parsers/spec_types/specification_type_parser.py
@@ -1,8 +1,8 @@
 from typing import Dict, Optional
 
-from reqif.helpers.lxml import lxml_is_self_closed_tag
-from reqif.models.reqif_specification_type import ReqIFSpecificationType
-from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
+from ...helpers.lxml import lxml_is_self_closed_tag
+from ...models.reqif_specification_type import ReqIFSpecificationType
+from ...parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
 class SpecificationTypeParser:

--- a/reqif/parsers/specification_parser.py
+++ b/reqif/parsers/specification_parser.py
@@ -1,12 +1,12 @@
 from typing import List, Optional
 
-from reqif.helpers.lxml import lxml_escape_for_html
-from reqif.models.reqif_spec_object import SpecObjectAttribute
-from reqif.models.reqif_specification import (
+from ..helpers.lxml import lxml_escape_for_html
+from ..models.reqif_spec_object import SpecObjectAttribute
+from ..models.reqif_specification import (
     ReqIFSpecification,
 )
-from reqif.parsers.attribute_value_parser import AttributeValueParser
-from reqif.parsers.spec_hierarchy_parser import (
+from .attribute_value_parser import AttributeValueParser
+from .spec_hierarchy_parser import (
     ReqIFSpecHierarchyParser,
 )
 

--- a/reqif/reqif_bundle.py
+++ b/reqif/reqif_bundle.py
@@ -1,20 +1,20 @@
 import collections
 from typing import Deque, Generator, List, Optional
 
-from reqif.helpers.debug import auto_described
-from reqif.models.error_handling import ReqIFSchemaError
-from reqif.models.reqif_core_content import ReqIFCoreContent
-from reqif.models.reqif_namespace_info import ReqIFNamespaceInfo
-from reqif.models.reqif_req_if_content import ReqIFReqIFContent
-from reqif.models.reqif_reqif_header import ReqIFReqIFHeader
-from reqif.models.reqif_spec_hierarchy import (
+from .helpers.debug import auto_described
+from .models.error_handling import ReqIFSchemaError
+from .models.reqif_core_content import ReqIFCoreContent
+from .models.reqif_namespace_info import ReqIFNamespaceInfo
+from .models.reqif_req_if_content import ReqIFReqIFContent
+from .models.reqif_reqif_header import ReqIFReqIFHeader
+from .models.reqif_spec_hierarchy import (
     ReqIFSpecHierarchy,
 )
-from reqif.models.reqif_spec_object import (
+from .models.reqif_spec_object import (
     ReqIFSpecObject,
 )
-from reqif.models.reqif_spec_object_type import ReqIFSpecObjectType
-from reqif.object_lookup import ReqIFObjectLookup
+from .models.reqif_spec_object_type import ReqIFSpecObjectType
+from .object_lookup import ReqIFObjectLookup
 
 
 @auto_described

--- a/reqif/specification_iterator.py
+++ b/reqif/specification_iterator.py
@@ -1,7 +1,7 @@
 import collections
 from typing import Deque, Generator
 
-from reqif.models.reqif_spec_hierarchy import ReqIFSpecHierarchy
+from .models.reqif_spec_hierarchy import ReqIFSpecHierarchy
 
 
 class SpecificationIterator:

--- a/reqif/unparser.py
+++ b/reqif/unparser.py
@@ -1,29 +1,29 @@
 from typing import List
 
-from reqif.models.reqif_namespace_info import ReqIFNamespaceInfo
-from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
-from reqif.models.reqif_spec_object_type import ReqIFSpecObjectType
-from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
-from reqif.models.reqif_specification_type import ReqIFSpecificationType
-from reqif.parsers.data_type_parser import DataTypeParser
-from reqif.parsers.header_parser import ReqIFHeaderParser
-from reqif.parsers.relation_group_parser import ReqIFRelationGroupParser
-from reqif.parsers.spec_object_parser import SpecObjectParser
-from reqif.parsers.spec_relation_parser import SpecRelationParser
-from reqif.parsers.spec_types.relation_group_type_parser import (
+from .models.reqif_namespace_info import ReqIFNamespaceInfo
+from .models.reqif_relation_group_type import ReqIFRelationGroupType
+from .models.reqif_spec_object_type import ReqIFSpecObjectType
+from .models.reqif_spec_relation_type import ReqIFSpecRelationType
+from .models.reqif_specification_type import ReqIFSpecificationType
+from .parsers.data_type_parser import DataTypeParser
+from .parsers.header_parser import ReqIFHeaderParser
+from .parsers.relation_group_parser import ReqIFRelationGroupParser
+from .parsers.spec_object_parser import SpecObjectParser
+from .parsers.spec_relation_parser import SpecRelationParser
+from .parsers.spec_types.relation_group_type_parser import (
     RelationGroupTypeParser,
 )
-from reqif.parsers.spec_types.spec_object_type_parser import (
+from .parsers.spec_types.spec_object_type_parser import (
     SpecObjectTypeParser,
 )
-from reqif.parsers.spec_types.spec_relation_type_parser import (
+from .parsers.spec_types.spec_relation_type_parser import (
     SpecRelationTypeParser,
 )
-from reqif.parsers.spec_types.specification_type_parser import (
+from .parsers.spec_types.specification_type_parser import (
     SpecificationTypeParser,
 )
-from reqif.parsers.specification_parser import ReqIFSpecificationParser
-from reqif.reqif_bundle import ReqIFBundle
+from .parsers.specification_parser import ReqIFSpecificationParser
+from .reqif_bundle import ReqIFBundle
 
 
 class ReqIFUnparser:


### PR DESCRIPTION
This set of commits changes the absolute "import reqif.XXX" or "from reqif.XXX import ..." statements to use the relative import syntax from PEP 328. This fixes a small development issue where a local copy of the module will still preferentially import the module installed in pip instead of the local copy. 