### PR TITLE
Fix parsing of empty enum values

### DIFF
--- a/reqif/parsers/attribute_definition_parser.py
+++ b/reqif/parsers/attribute_definition_parser.py
@@ -208,7 +208,8 @@ class AttributeDefinitionParser:
                             xml_values = xml_attribute_value.find("VALUES")
                             if xml_values is not None:
                                 xml_enum_value_ref = xml_values.find("ENUM-VALUE-REF")
-                                default_value = xml_enum_value_ref.text
+                                if xml_enum_value_ref is not None:
+                                    default_value = xml_enum_value_ref.text
                         else:
                             raise NotImplementedError
             elif attribute_definition.tag == "ATTRIBUTE-DEFINITION-DATE":


### PR DESCRIPTION
Hello,

I encountered a bug when parsing reqif files that have enums with empty values.
Usually enums are defined like this:
```html
<ATTRIBUTE-VALUE-ENUMERATION>
  <DEFINITION>
    <ATTRIBUTE-DEFINITION-ENUMERATION-REF>_e46959d6-693d-48e4-aec5-0b25c2df246a</ATTRIBUTE-DEFINITION-ENUMERATION-REF>
  </DEFINITION>
  <VALUES>
    <ENUM-VALUE-REF>_85049ee4-44c4-4353-be47-a23549c787ad</ENUM-VALUE-REF>
  </VALUES>
</ATTRIBUTE-VALUE-ENUMERATION>
``` 

But they can also look like this when there is no value:

```html
<ATTRIBUTE-VALUE-ENUMERATION>
  <DEFINITION>
  	<ATTRIBUTE-DEFINITION-ENUMERATION-REF>_c2acab98-2754-497b-9d5e-e5ca920c0a2f</ATTRIBUTE-DEFINITION-ENUMERATION-REF>
  </DEFINITION>
  <VALUES/>
</ATTRIBUTE-VALUE-ENUMERATION>
``` 
In the latter case the parser raises an exception, as cannot find "ENUM-VALUE-REF" in "VALUES", but tries to access it anyway. I added a simple None check to prevent this error.