### PR TITLE
chore(tasks): set mypy baseline to 3.9

### DIFF
--- a/reqif/parser.py
+++ b/reqif/parser.py
@@ -1,3 +1,6 @@
+# Ignoring for now:
+# A005 Module `parser` shadows a Python standard-library module.
+# ruff: noqa: A005
 import copy
 import io
 import os

--- a/tasks.py
+++ b/tasks.py
@@ -141,7 +141,7 @@ def lint_mypy(context):
             --disable-error-code=type-arg
             --disable-error-code=union-attr
             --strict
-            --python-version=3.8
+            --python-version=3.9
         """,
     )
 


### PR DESCRIPTION
It looks like mypy dropped the 3.8 support, so we need to migrate.