### PR TITLE
Feature: parsing ATTRIBUTE-DEFINITION-DATE default values

### DIFF
--- a/reqif/parsers/attribute_definition_parser.py
+++ b/reqif/parsers/attribute_definition_parser.py
@@ -135,6 +135,7 @@ class AttributeDefinitionParser:
                         )
                         if xml_attribute_definition is not None:
                             default_value_definition_ref = xml_attribute_definition.text
+
             elif attribute_definition.tag == "ATTRIBUTE-DEFINITION-XHTML":
                 attribute_type = SpecObjectAttributeType.XHTML
                 try:
@@ -167,6 +168,7 @@ class AttributeDefinitionParser:
                         default_value = lxml_stringify_namespaced_children(xml_values)
                     else:
                         raise NotImplementedError
+
             elif attribute_definition.tag == "ATTRIBUTE-DEFINITION-ENUMERATION":
                 attribute_type = SpecObjectAttributeType.ENUMERATION
                 multi_valued_string = (
@@ -210,6 +212,7 @@ class AttributeDefinitionParser:
                                     default_value = xml_enum_value_ref.text
                         else:
                             raise NotImplementedError
+
             elif attribute_definition.tag == "ATTRIBUTE-DEFINITION-DATE":
                 attribute_type = SpecObjectAttributeType.DATE
                 try:
@@ -220,6 +223,13 @@ class AttributeDefinitionParser:
                     )
                 except Exception as exception:
                     raise NotImplementedError(attribute_definition) from exception
+
+                xml_default_value = attribute_definition.find("DEFAULT-VALUE")
+                if xml_default_value is not None:
+                    xml_attribute_value = xml_default_value.find("ATTRIBUTE-VALUE-DATE")
+                    assert xml_attribute_value is not None
+                    default_value = xml_attribute_value.attrib["THE-VALUE"]
+
             else:
                 raise NotImplementedError(attribute_definition) from None
             attribute_definition = SpecAttributeDefinition(

--- a/tests/unit/reqif/parsers/test_spec_type_parser.py
+++ b/tests/unit/reqif/parsers/test_spec_type_parser.py
@@ -202,3 +202,36 @@ def test_07_real_attribute_definition_with_default_value() -> None:
         == "TEST_REAL_ATTRIBUTE_LONG_NAME"
     )
     assert reqif_spec_object_type.attribute_definitions[0].default_value == "3.14"
+
+
+def test_08_date_attribute_definition_with_default_value() -> None:
+    spec_type_string = """
+<SPEC-OBJECT-TYPE IDENTIFIER="TEST_SPEC_OBJECT_TYPE_ID" LAST-CHANGE="2021-02-08T16:37:07.454+01:00" LONG-NAME="TEST_SPEC_OBJECT_TYPE_LONG_NAME">
+  <SPEC-ATTRIBUTES>
+    <ATTRIBUTE-DEFINITION-DATE IDENTIFIER="TEST_DATE_ATTRIBUTE_ID" LONG-NAME="TEST_DATE_ATTRIBUTE_LONG_NAME" IS-EDITABLE="false">
+      <DEFAULT-VALUE>
+        <ATTRIBUTE-VALUE-DATE THE-VALUE="2005-06-05T22:03:35+02:00"/>
+      </DEFAULT-VALUE>
+      <TYPE>
+        <DATATYPE-DEFINITION-DATE-REF>TEST_DATE_TYPE</DATATYPE-DEFINITION-DATE-REF>
+      </TYPE>
+    </ATTRIBUTE-DEFINITION-DATE>
+  </SPEC-ATTRIBUTES>
+</SPEC-OBJECT-TYPE>
+    """  # noqa: E501
+    spec_type_xml = etree.fromstring(spec_type_string)
+
+    reqif_spec_object_type = SpecObjectTypeParser.parse(spec_type_xml)
+    assert isinstance(reqif_spec_object_type, ReqIFSpecObjectType)
+    assert reqif_spec_object_type.identifier == "TEST_SPEC_OBJECT_TYPE_ID"
+    assert reqif_spec_object_type.long_name == "TEST_SPEC_OBJECT_TYPE_LONG_NAME"
+    attribute_map = reqif_spec_object_type.attribute_map
+    assert len(attribute_map) == 1
+    assert (
+        attribute_map.get("TEST_DATE_ATTRIBUTE_ID").long_name
+        == "TEST_DATE_ATTRIBUTE_LONG_NAME"
+    )
+    assert (
+        reqif_spec_object_type.attribute_definitions[0].default_value
+        == "2005-06-05T22:03:35+02:00"
+    )


### PR DESCRIPTION
Found one more inconsistency with parsing of `DEFAULT-VALUE`s. In `ATTRIBUTE-DEFINITION-DATE`, `DEFAULT-VALUE`s were silently ignored — the default value was never extracted. This adds support for reading the `ATTRIBUTE-VALUE-DATE` child element, consistent with how other attribute types handle default values.

A unit test covering this case is also added.