### PR TITLE
fix: handle SPEC-ATTRIBUTES on RELATION-GROUP-TYPE and DEFAULT-VALUE …

### DIFF
--- a/reqif/models/reqif_relation_group_type.py
+++ b/reqif/models/reqif_relation_group_type.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from typing import List, Optional
+
+from reqif.models.reqif_spec_object_type import SpecAttributeDefinition
 
 
 class ReqIFRelationGroupType:
@@ -9,9 +11,13 @@ class ReqIFRelationGroupType:
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         is_self_closed: bool = True,
+        attribute_definitions: Optional[List[SpecAttributeDefinition]] = None,
     ):
         self.identifier: str = identifier
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name
         self.is_self_closed: bool = is_self_closed
+        self.attribute_definitions: Optional[List[SpecAttributeDefinition]] = (
+            attribute_definitions
+        )

--- a/reqif/parsers/spec_types/relation_group_type_parser.py
+++ b/reqif/parsers/spec_types/relation_group_type_parser.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from reqif.helpers.lxml import lxml_is_self_closed_tag
 from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
+from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
 class RelationGroupTypeParser:
@@ -31,12 +32,17 @@ class RelationGroupTypeParser:
             xml_attributes["LAST-CHANGE"] if "LAST-CHANGE" in xml_attributes else None
         )
 
+        attribute_definitions = AttributeDefinitionParser.parse_attribute_definitions(
+            xml_spec_relation_type_xml
+        )
+
         return ReqIFRelationGroupType(
             is_self_closed=is_self_closed,
             description=description,
             identifier=identifier,
             last_change=last_change,
             long_name=long_name,
+            attribute_definitions=attribute_definitions,
         )
 
     @staticmethod
@@ -51,7 +57,16 @@ class RelationGroupTypeParser:
             output += f' LONG-NAME="{spec_relation_type.long_name}"'
         if spec_relation_type.is_self_closed:
             output += "/>\n"
-        else:
-            output += ">\n"
-            output += "        </RELATION-GROUP-TYPE>\n"
+            return output
+
+        output += ">\n"
+
+        if spec_relation_type.attribute_definitions is not None:
+            output += "          <SPEC-ATTRIBUTES>\n"
+            output += AttributeDefinitionParser.unparse_xhtml_attribute_definition(
+                attribute_definitions=spec_relation_type.attribute_definitions
+            )
+            output += "          </SPEC-ATTRIBUTES>\n"
+
+        output += "        </RELATION-GROUP-TYPE>\n"
         return output

--- a/reqif/parsers/spec_types/specification_type_parser.py
+++ b/reqif/parsers/spec_types/specification_type_parser.py
@@ -75,32 +75,9 @@ class SpecificationTypeParser:
 
         if spec_type.spec_attributes is not None:
             output += "          <SPEC-ATTRIBUTES>\n"
-
-            for attribute in spec_type.spec_attributes:
-                output += f"            <{attribute.attribute_type.get_spec_type_tag()}"
-                if attribute.description is not None:
-                    output += f' DESC="{attribute.description}"'
-                output += f' IDENTIFIER="{attribute.identifier}"'
-                if attribute.editable is not None:
-                    editable_value = "true" if attribute.editable else "false"
-                    output += f' IS-EDITABLE="{editable_value}"'
-                if attribute.last_change:
-                    output += f' LAST-CHANGE="{attribute.last_change}"'
-                output += f' LONG-NAME="{attribute.long_name}"'
-                output += ">\n"
-                output += "              <TYPE>\n"
-                output += (
-                    "                "
-                    f"<{attribute.attribute_type.get_definition_tag()}>"
-                    f"{attribute.datatype_definition}"
-                    f"</{attribute.attribute_type.get_definition_tag()}>"
-                    "\n"
-                )
-                output += "              </TYPE>\n"
-                output += "            </"
-                output += f"{attribute.attribute_type.get_spec_type_tag()}"
-                output += ">\n"
-
+            output += AttributeDefinitionParser.unparse_xhtml_attribute_definition(
+                attribute_definitions=spec_type.spec_attributes
+            )
             output += "          </SPEC-ATTRIBUTES>\n"
 
         output += "        </SPECIFICATION-TYPE>\n"

--- a/tests/integration/reqif/RELATION-GROUP-TYPE/02_spec_attributes/sample.reqif
+++ b/tests/integration/reqif/RELATION-GROUP-TYPE/02_spec_attributes/sample.reqif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd" xmlns:configuration="http://eclipse.org/rmf/pror/toolextensions/1.0">
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES>
+        <DATATYPE-DEFINITION-STRING IDENTIFIER="_dtype_String" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="String" MAX-LENGTH="1024"/>
+      </DATATYPES>
+      <SPEC-TYPES>
+        <RELATION-GROUP-TYPE IDENTIFIER="ID_RelationGroupType_WithAttrs" LAST-CHANGE="2012-04-07T01:51:37.112+02:00" LONG-NAME="Relation Group Type With Attributes">
+          <SPEC-ATTRIBUTES>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="_attr_rgt_string" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="Comment">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>_dtype_String</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+          </SPEC-ATTRIBUTES>
+        </RELATION-GROUP-TYPE>
+      </SPEC-TYPES>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>

--- a/tests/integration/reqif/RELATION-GROUP-TYPE/02_spec_attributes/test.itest
+++ b/tests/integration/reqif/RELATION-GROUP-TYPE/02_spec_attributes/test.itest
@@ -1,0 +1,3 @@
+RUN: mkdir -p %S/output
+RUN: %reqif passthrough %S/sample.reqif %S/output/sample.reqif
+RUN: %diff %S/sample.reqif %S/output/sample.reqif

--- a/tests/integration/reqif/SPECIFICATION-TYPE/03_spec_attribute_default_value/sample.reqif
+++ b/tests/integration/reqif/SPECIFICATION-TYPE/03_spec_attribute_default_value/sample.reqif
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd" xmlns:configuration="http://eclipse.org/rmf/pror/toolextensions/1.0">
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES>
+        <DATATYPE-DEFINITION-STRING IDENTIFIER="_dtype_String" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="String" MAX-LENGTH="1024"/>
+      </DATATYPES>
+      <SPEC-TYPES>
+        <SPECIFICATION-TYPE IDENTIFIER="TEST_SPECIFICATION_TYPE_ID" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="TEST_SPECIFICATION_TYPE_LONG_NAME">
+          <SPEC-ATTRIBUTES>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="TEST_SPEC_ATTRIBUTE_ID" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="Title">
+              <DEFAULT-VALUE>
+                <ATTRIBUTE-VALUE-STRING THE-VALUE="Untitled"/>
+              </DEFAULT-VALUE>
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>_dtype_String</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+          </SPEC-ATTRIBUTES>
+        </SPECIFICATION-TYPE>
+      </SPEC-TYPES>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>

--- a/tests/integration/reqif/SPECIFICATION-TYPE/03_spec_attribute_default_value/test.itest
+++ b/tests/integration/reqif/SPECIFICATION-TYPE/03_spec_attribute_default_value/test.itest
@@ -1,0 +1,3 @@
+RUN: mkdir -p %S/output
+RUN: %reqif passthrough %S/sample.reqif %S/output/sample.reqif
+RUN: %diff %S/sample.reqif %S/output/sample.reqif

--- a/tests/unit/reqif/parsers/test_relation_group_type_parser.py
+++ b/tests/unit/reqif/parsers/test_relation_group_type_parser.py
@@ -1,0 +1,39 @@
+from lxml import etree
+
+from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
+from reqif.parsers.spec_types.relation_group_type_parser import RelationGroupTypeParser
+
+
+def test_01_no_spec_attributes() -> None:
+    xml = etree.fromstring(
+        '<RELATION-GROUP-TYPE IDENTIFIER="RGT_ID" LAST-CHANGE="2012-04-07T01:51:37.112+02:00" LONG-NAME="RGT"/>'
+    )
+    result = RelationGroupTypeParser.parse(xml)
+    assert isinstance(result, ReqIFRelationGroupType)
+    assert result.identifier == "RGT_ID"
+    assert result.attribute_definitions is None
+
+
+def test_02_spec_attributes_round_trip() -> None:
+    xml_string = """\
+<RELATION-GROUP-TYPE IDENTIFIER="RGT_ID" LAST-CHANGE="2012-04-07T01:51:37.112+02:00" LONG-NAME="RGT With Attrs">
+  <SPEC-ATTRIBUTES>
+    <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="_attr_comment" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="Comment">
+      <TYPE>
+        <DATATYPE-DEFINITION-STRING-REF>_dtype_String</DATATYPE-DEFINITION-STRING-REF>
+      </TYPE>
+    </ATTRIBUTE-DEFINITION-STRING>
+  </SPEC-ATTRIBUTES>
+</RELATION-GROUP-TYPE>"""
+    xml = etree.fromstring(xml_string)
+    result = RelationGroupTypeParser.parse(xml)
+    assert isinstance(result, ReqIFRelationGroupType)
+    assert result.attribute_definitions is not None
+    assert len(result.attribute_definitions) == 1
+    assert result.attribute_definitions[0].identifier == "_attr_comment"
+    assert result.attribute_definitions[0].long_name == "Comment"
+
+    unparsed = RelationGroupTypeParser.unparse(result)
+    assert "SPEC-ATTRIBUTES" in unparsed
+    assert "_attr_comment" in unparsed
+    assert "Comment" in unparsed

--- a/tests/unit/reqif/parsers/test_specification_type_parser.py
+++ b/tests/unit/reqif/parsers/test_specification_type_parser.py
@@ -6,6 +6,30 @@ from reqif.parsers.spec_types.specification_type_parser import (
 )
 
 
+def test_02_default_value_survives_unparse() -> None:
+    spec_type_string = """\
+        <SPECIFICATION-TYPE IDENTIFIER="ST_ID" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="ST">
+          <SPEC-ATTRIBUTES>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="_attr_title" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="Title">
+              <DEFAULT-VALUE>
+                <ATTRIBUTE-VALUE-STRING THE-VALUE="Untitled"/>
+              </DEFAULT-VALUE>
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>_dtype_String</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+          </SPEC-ATTRIBUTES>
+        </SPECIFICATION-TYPE>"""
+    xml = etree.fromstring(spec_type_string)
+    result = SpecificationTypeParser.parse(xml)
+    assert result.spec_attributes is not None
+    assert result.spec_attributes[0].default_value == "Untitled"
+
+    unparsed = SpecificationTypeParser.unparse(result)
+    assert "DEFAULT-VALUE" in unparsed
+    assert "Untitled" in unparsed
+
+
 def test_01_nominal_case() -> None:
     spec_type_string = """
         <SPECIFICATION-TYPE IDENTIFIER="TEST_SPECIFICATION_TYPE_ID" LAST-CHANGE="2015-12-14T02:04:51.769+01:00" LONG-NAME="TEST_SPECIFICATION_TYPE_LONG_NAME">


### PR DESCRIPTION
…on SPECIFICATION-TYPE attributes

  Bug A: ReqIFRelationGroupType had no attribute_definitions field, so any
  SPEC-ATTRIBUTES children of RELATION-GROUP-TYPE were silently dropped on
  parse and never emitted on unparse. Add the field and wire
  AttributeDefinitionParser into both directions, matching the existing
  pattern in SpecRelationTypeParser.

  Bug B: SpecificationTypeParser.unparse had its own attribute-serialization
  loop that omitted DEFAULT-VALUE. Delegate to
  AttributeDefinitionParser.unparse_xhtml_attribute_definition (which
  already handles DEFAULT-VALUE correctly), as SpecObjectTypeParser and
  SpecRelationTypeParser already do.

  Add unit tests and integration fixtures covering both cases.