### PR TITLE
fix: don't drop attribute_definitions on self-closed SPEC-*-TYPE unparse

### DIFF
--- a/reqif/parsers/spec_types/relation_group_type_parser.py
+++ b/reqif/parsers/spec_types/relation_group_type_parser.py
@@ -55,7 +55,11 @@ class RelationGroupTypeParser:
             output += f' LAST-CHANGE="{spec_relation_type.last_change}"'
         if spec_relation_type.long_name is not None:
             output += f' LONG-NAME="{spec_relation_type.long_name}"'
-        if spec_relation_type.is_self_closed:
+        has_attributes = (
+            spec_relation_type.attribute_definitions is not None
+            and len(spec_relation_type.attribute_definitions) > 0
+        )
+        if spec_relation_type.is_self_closed and not has_attributes:
             output += "/>\n"
             return output
 

--- a/reqif/parsers/spec_types/spec_relation_type_parser.py
+++ b/reqif/parsers/spec_types/spec_relation_type_parser.py
@@ -52,7 +52,11 @@ class SpecRelationTypeParser:
             output += f' LAST-CHANGE="{spec_relation_type.last_change}"'
         if spec_relation_type.long_name is not None:
             output += f' LONG-NAME="{spec_relation_type.long_name}"'
-        if spec_relation_type.is_self_closed:
+        has_attributes = (
+            spec_relation_type.attribute_definitions is not None
+            and len(spec_relation_type.attribute_definitions) > 0
+        )
+        if spec_relation_type.is_self_closed and not has_attributes:
             output += "/>\n"
             return output
 

--- a/reqif/parsers/spec_types/specification_type_parser.py
+++ b/reqif/parsers/spec_types/specification_type_parser.py
@@ -67,7 +67,10 @@ class SpecificationTypeParser:
             output += f' LONG-NAME="{spec_type.long_name}"'
 
         # Some documents have a SPECIFICATION-TYPE without any SPEC-ATTRIBUTES.
-        if spec_type.is_self_closed:
+        has_attributes = (
+            spec_type.spec_attributes is not None and len(spec_type.spec_attributes) > 0
+        )
+        if spec_type.is_self_closed and not has_attributes:
             output += "/>\n"
             return output
         else:


### PR DESCRIPTION
Symmetric to #214's parse-side fix. When a `SPEC-RELATION-TYPE` / `RELATION-GROUP-TYPE` / `SPECIFICATION-TYPE` IR object has `is_self_closed=True` but also carries `attribute_definitions`, the unparser's `if is_self_closed: return "/>\n"` short-circuit fires before the `<SPEC-ATTRIBUTES>` block emits, silently dropping the attributes.

Fix: gate the shortcut on the absence of attributes in all three unparsers. Should merge after #214.