### PR TITLE
fix: capture <REQ-IF> opening tag without O(N²) tree mutation

### DIFF
--- a/reqif/parser.py
+++ b/reqif/parser.py
@@ -133,14 +133,28 @@ class ReqIFParser:
                 f"Expected root tag to be REQ-IF, got: {xml_reqif_nons_root.tag}."
             ) from None
 
-        # The best workaround I could find for getting the exact content of
-        # the namespaces and attributes of the <REQ-IF ...> tag.
+        # Capture the exact content of the namespaces and attributes of the
+        # <REQ-IF ...> tag. lxml has no API to serialize only an element's
+        # opening tag (etree.tostring always serializes the whole subtree), so
+        # serialize a shallow copy of the root that carries the same tag,
+        # nsmap, and attributes but no children.
         # https://stackoverflow.com/questions/74879238
-        xml_reqif_root_2 = xml_reqif.getroot()
-        for child in list(xml_reqif_root_2):
-            xml_reqif_root_2.remove(child)
+        # NB: this must read from the original (non-namespace-stripped) tree,
+        # and must not mutate it. Removing the <CORE-CONTENT> child instead, as
+        # earlier versions did, forced libxml2 to reconcile namespaces across
+        # the whole detached spec-object subtree, which is O(N^2) in the number
+        # of spec objects.
+        xml_reqif_root = xml_reqif.getroot()
+        shallow_root = etree.Element(xml_reqif_root.tag, nsmap=xml_reqif_root.nsmap)
+        # Empty (rather than absent) text reproduces the previous output for
+        # pretty-printed inputs: the root is serialized as <REQ-IF ...></REQ-IF>
+        # rather than the self-closing <REQ-IF .../>, before </REQ-IF> is
+        # stripped below.
+        shallow_root.text = ""
+        for attribute_name, attribute_value in xml_reqif_root.attrib.items():
+            shallow_root.set(attribute_name, attribute_value)
         original_reqif_tag_dump = etree.tostring(
-            xml_reqif_root_2, pretty_print=True
+            shallow_root, pretty_print=True
         ).decode("utf8")
         original_reqif_tag_dump = original_reqif_tag_dump.replace(
             "</REQ-IF>", ""


### PR DESCRIPTION
`ReqIFParser._parse_reqif` records the original `<REQ-IF …>` opening tag (its namespace declarations and attributes) for faithful round-trip unparsing. It did this by deleting every child
of the parsed root and serializing the now-empty root. Removing the `CORE-CONTENT` child forced `libxml2` to reconcile namespaces across the entire detached spec-object subtree — O(N²) in
the number of spec objects, accounting for roughly two-thirds of total parse time on large files (tens of minutes at 100k objects).

Fix

Serialize a shallow copy of the root (same tag, nsmap, and attrib, no children) instead of mutating the parsed tree. `lxml` has no API to serialize an element's opening tag alone, so a
childless copy is the linear way to isolate it. This is also non-destructive — it removes the prior side effect of emptying the caller's tree.

Behavior

- Byte-identical opening tag for pretty-printed (real-world) inputs; verified against the Polarion and SDoc round-trip fixtures.
- For inputs with no whitespace after the opening tag, output normalizes self-closing `<REQ-IF .../>` to `<REQ-IF ...>` — the correct form for an opening-tag capture; does not occur in
pretty-printed files.

Performance

Full parse_from_string is now linear: ~0.17 s at 20k objects and ~0.35 s at 40k, versus the old capture block alone taking ~14 s and ~84 s.

Tests

Unit 49/49 pass; integration 78/79 (the one failure is an environmental missing `libtidy`, unrelated).
