### PR TITLE
fix: tolerate ENUM-VALUE without PROPERTIES in DataTypeParser

### DIFF
--- a/reqif/models/reqif_data_type.py
+++ b/reqif/models/reqif_data_type.py
@@ -104,14 +104,14 @@ class ReqIFEnumValue:
     def __init__(  # pylint: disable=too-many-arguments
         self,
         identifier: str,
-        key: str,
+        key: Optional[str],
         description: Optional[str] = None,
         last_change: Optional[str] = None,
         other_content: Optional[str] = None,
         long_name: Optional[str] = None,
     ):
         self.identifier: str = identifier
-        self.key: str = key
+        self.key: Optional[str] = key
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.other_content: Optional[str] = other_content

--- a/reqif/parsers/data_type_parser.py
+++ b/reqif/parsers/data_type_parser.py
@@ -65,16 +65,23 @@ class DataTypeParser:
                         else None
                     )
                     properties = xml_specified_value.find("PROPERTIES")
-
-                    embedded_value = properties.find("EMBEDDED-VALUE")
-                    embedded_value_attributes = embedded_value.attrib
-
-                    embedded_value_key = embedded_value_attributes["KEY"]
-                    embedded_value_other_content = (
-                        embedded_value_attributes["OTHER-CONTENT"]
-                        if "OTHER-CONTENT" in embedded_value_attributes
+                    embedded_value = (
+                        properties.find("EMBEDDED-VALUE")
+                        if properties is not None
                         else None
                     )
+
+                    if embedded_value is not None:
+                        embedded_value_attributes = embedded_value.attrib
+                        embedded_value_key = embedded_value_attributes["KEY"]
+                        embedded_value_other_content = (
+                            embedded_value_attributes["OTHER-CONTENT"]
+                            if "OTHER-CONTENT" in embedded_value_attributes
+                            else None
+                        )
+                    else:
+                        embedded_value_key = None
+                        embedded_value_other_content = None
                     values.append(
                         ReqIFEnumValue(
                             description=specified_value_description,
@@ -293,12 +300,13 @@ class DataTypeParser:
                         output += f' LONG-NAME="{escaped_long_name}"'
                     output += ">\n"
 
-                    output += "              <PROPERTIES>\n"
-                    output += f'                <EMBEDDED-VALUE KEY="{value.key}"'
-                    if value.other_content is not None:
-                        output += f' OTHER-CONTENT="{value.other_content}"'
-                    output += "/>\n"
-                    output += "              </PROPERTIES>\n"
+                    if value.key is not None:
+                        output += "              <PROPERTIES>\n"
+                        output += f'                <EMBEDDED-VALUE KEY="{value.key}"'
+                        if value.other_content is not None:
+                            output += f' OTHER-CONTENT="{value.other_content}"'
+                        output += "/>\n"
+                        output += "              </PROPERTIES>\n"
 
                     output += "            </ENUM-VALUE>\n"
 

--- a/tests/unit/reqif/parsers/test_data_type_parser.py
+++ b/tests/unit/reqif/parsers/test_data_type_parser.py
@@ -65,3 +65,29 @@ def test_02_enumeration_type():
 
     assert value_1.key == "1"
     assert value_2.key == "2"
+
+
+def test_03_enumeration_value_without_properties():
+    spec_type_string = """
+<DATATYPE-DEFINITION-ENUMERATION
+  IDENTIFIER="NODE_TYPE"
+  LONG-NAME="T_Kind">
+  <SPECIFIED-VALUES>
+    <ENUM-VALUE
+      IDENTIFIER="NODE_TYPE_SECTION"
+      LONG-NAME="ordinary"
+    >
+    </ENUM-VALUE>
+  </SPECIFIED-VALUES>
+</DATATYPE-DEFINITION-ENUMERATION>
+    """
+    spec_type_xml = etree.fromstring(spec_type_string)
+
+    data_type = DataTypeParser.parse(spec_type_xml)
+    assert isinstance(data_type, ReqIFDataTypeDefinitionEnumeration)
+
+    value = data_type.values_map["NODE_TYPE_SECTION"]
+    assert value.key is None
+
+    unparsed = DataTypeParser.unparse(data_type)
+    assert "PROPERTIES" not in unparsed


### PR DESCRIPTION
`DataTypeParser.parse` assumed every `ENUM-VALUE` carries a `PROPERTIES`/`EMBEDDED-VALUE` child, so parsing crashed with `AttributeError: 'NoneType' object has no attribute 'find'` on real-world IBM Rational DOORS exports (e.g. the public openETCS SUBSET-026 package) that omit `PROPERTIES`. Since DATATYPES parse first, the whole document failed before any spec object was read.

This treats a missing `PROPERTIES`/`EMBEDDED-VALUE` as `key=None`, and the unparser now skips the `<PROPERTIES>` block for such values so round-trip output stays faithful to the input. Added a unit test covering both the parse and the round-trip; the existing `tests/unit` suite stays green (56 passed).

Closes #222
