### PR TITLE
fix: tolerate ATTRIBUTE-VALUE-ENUMERATION without VALUES element

### DIFF
--- a/reqif/parsers/attribute_value_parser.py
+++ b/reqif/parsers/attribute_value_parser.py
@@ -115,12 +115,15 @@ class AttributeValueParser:
                     .text
                 )
                 attribute_xml_values = attribute_xml.find("VALUES")
-                assert attribute_xml_values is not None
-                xml_enum_value_refs = attribute_xml_values.getchildren()
                 enum_value_refs: List[str] = []
-                for xml_enum_value_ref in xml_enum_value_refs:
-                    attribute_value = xml_enum_value_ref.text
-                    enum_value_refs.append(attribute_value)
+                # Some ALM tools omit the <VALUES> element entirely to represent
+                # "no enum value selected" instead of emitting an empty <VALUES/>.
+                # Treat a missing <VALUES> as an empty value list.
+                if attribute_xml_values is not None:
+                    xml_enum_value_refs = attribute_xml_values.getchildren()
+                    for xml_enum_value_ref in xml_enum_value_refs:
+                        attribute_value = xml_enum_value_ref.text
+                        enum_value_refs.append(attribute_value)
                 attribute = SpecObjectAttribute(
                     xml_node=attribute_xml,
                     attribute_type=SpecObjectAttributeType.ENUMERATION,

--- a/tests/unit/reqif/parsers/test_spec_object_parser.py
+++ b/tests/unit/reqif/parsers/test_spec_object_parser.py
@@ -56,6 +56,34 @@ def test_03_missing_values_element():
     assert spec_object.attributes == []
 
 
+def test_04_enumeration_attribute_missing_values_element():
+    """An ATTRIBUTE-VALUE-ENUMERATION may omit its <VALUES> child.
+
+    Some ALM tools export an unset enumeration attribute without a <VALUES>
+    element (rather than an empty <VALUES/>). Parsing must treat it as an
+    empty value list instead of raising.
+    """
+    spec_object_string = """
+<SPEC-OBJECT IDENTIFIER="TEST_ENUM_NO_VALUES_ID" LAST-CHANGE="2021-10-15T11:32:40.205+02:00">
+  <VALUES>
+    <ATTRIBUTE-VALUE-ENUMERATION>
+      <DEFINITION>
+        <ATTRIBUTE-DEFINITION-ENUMERATION-REF>TEST_FIELD_STATUS</ATTRIBUTE-DEFINITION-ENUMERATION-REF>
+      </DEFINITION>
+    </ATTRIBUTE-VALUE-ENUMERATION>
+  </VALUES>
+  <TYPE>
+    <SPEC-OBJECT-TYPE-REF>TEST_SPEC_OBJECT_TYPE</SPEC-OBJECT-TYPE-REF>
+  </TYPE>
+</SPEC-OBJECT>
+    """  # noqa: E501
+
+    spec_object_xml = etree.fromstring(spec_object_string)
+    spec_object = SpecObjectParser.parse(spec_object_xml)
+    assert spec_object.identifier == "TEST_ENUM_NO_VALUES_ID"
+    assert spec_object.attribute_map["TEST_FIELD_STATUS"].value == []
+
+
 def test_02_attributes_xhtml():
     spec_object_string = """\
 <SPEC-OBJECT xmlns:reqif-xhtml="http://www.w3.org/1999/xhtml" IDENTIFIER="TEST_SPEC_OBJECT_ID" LAST-CHANGE="2021-10-15T11:32:40.205+02:00">


### PR DESCRIPTION
### Problem
  
  `AttributeValueParser.parse_attribute_values` asserts that every
  `ATTRIBUTE-VALUE-ENUMERATION` has a `<VALUES>` child and crashes with an
  `AssertionError` otherwise:

  ```text
  File "reqif/parsers/attribute_value_parser.py", line 118, in parse_attribute_values
      assert attribute_xml_values is not None
  AssertionError
  ```

  Some ALM tools export an *unset* enumeration attribute by omitting the
  `<VALUES>` element entirely instead of emitting an empty `<VALUES/>`, e.g.:

  ```xml
  <ATTRIBUTE-VALUE-ENUMERATION>
    <DEFINITION>
      <ATTRIBUTE-DEFINITION-ENUMERATION-REF>SubTyp</ATTRIBUTE-DEFINITION-ENUMERATION-REF>
    </DEFINITION>
  </ATTRIBUTE-VALUE-ENUMERATION>
  ```

  This is a valid representation of "no enum value selected", so parsing it should
  succeed with an empty value list rather than raise.

  Change

  Guard the <VALUES> lookup: a missing <VALUES> now yields an empty enum value
  list. Mirrors the existing tolerance for a SPEC-OBJECT with no <VALUES> and
  for ENUM-VALUE without PROPERTIES (#223).

  Added test_04_enumeration_attribute_missing_values_element. Full unit suite
  passes (57 passed).