### PR TITLE
feat: support DESC attribute on SPEC-HIERARCHY

### DIFF
--- a/reqif/models/reqif_spec_hierarchy.py
+++ b/reqif/models/reqif_spec_hierarchy.py
@@ -12,6 +12,7 @@ class ReqIFSpecHierarchy:  # pylint: disable=too-many-instance-attributes
         spec_object: str,
         level: int,
         children: Optional[List["ReqIFSpecHierarchy"]] = None,
+        description: Optional[str] = None,
         long_name: Optional[str] = None,
         ref_then_children_order: bool = True,
         last_change: Optional[str] = None,
@@ -30,6 +31,7 @@ class ReqIFSpecHierarchy:  # pylint: disable=too-many-instance-attributes
 
         # Optional fields
         self.children: Optional[List[ReqIFSpecHierarchy]] = children
+        self.description: Optional[str] = description
         self.long_name: Optional[str] = long_name
         # Not part of REqIF, but helpful for printing the
         # <OBJECT> and <CHILDREN> tags depending on which tool produced the

--- a/reqif/parsers/spec_hierarchy_parser.py
+++ b/reqif/parsers/spec_hierarchy_parser.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from reqif.helpers.lxml import lxml_is_self_closed_tag
+from reqif.helpers.lxml import lxml_escape_for_html, lxml_is_self_closed_tag
 from reqif.models.reqif_spec_hierarchy import (
     ReqIFSpecHierarchy,
 )
@@ -16,6 +16,9 @@ class ReqIFSpecHierarchyParser:
             identifier = attributes["IDENTIFIER"]
         except Exception:
             raise NotImplementedError from None
+        description: Optional[str] = (
+            attributes["DESC"] if "DESC" in attributes else None
+        )
         last_change: Optional[str] = (
             attributes["LAST-CHANGE"] if "LAST-CHANGE" in attributes else None
         )
@@ -53,6 +56,7 @@ class ReqIFSpecHierarchyParser:
                 spec_hierarchy_children.append(child_spec_hierarchy)
         return ReqIFSpecHierarchy(
             identifier=identifier,
+            description=description,
             last_change=last_change,
             long_name=long_name,
             editable=editable,
@@ -69,9 +73,11 @@ class ReqIFSpecHierarchyParser:
     def unparse(hierarchy: ReqIFSpecHierarchy) -> str:
         base_level = hierarchy.calculate_base_level()
         base_level_str: str = " " * base_level
-        output: str = (
-            base_level_str + f'<SPEC-HIERARCHY IDENTIFIER="{hierarchy.identifier}"'
-        )
+        output: str = base_level_str + "<SPEC-HIERARCHY"
+        if hierarchy.description is not None:
+            escaped_description = lxml_escape_for_html(hierarchy.description)
+            output += f' DESC="{escaped_description}"'
+        output += f' IDENTIFIER="{hierarchy.identifier}"'
         if hierarchy.editable is not None:
             editable_value = "true" if hierarchy.editable else "false"
             output += f' IS-EDITABLE="{editable_value}"'

--- a/tests/unit/reqif/parsers/test_spec_hierarchy.py
+++ b/tests/unit/reqif/parsers/test_spec_hierarchy.py
@@ -44,3 +44,38 @@ def test_01_nominal_case() -> None:
     assert specification_1_1_1.identifier == "LEVEL_1_1_1"
     assert specification_1_1_1.children is None
     assert specification_1_1_1.level == 3
+
+
+def test_02_desc() -> None:
+    specification_string = """\
+<SPEC-HIERARCHY DESC="Some &amp; description" IDENTIFIER="LEVEL_1" LAST-CHANGE="2015-12-14T02:04:51.856+01:00">
+  <OBJECT>
+    <SPEC-OBJECT-REF>TEST_OBJECT_REF_1</SPEC-OBJECT-REF>
+  </OBJECT>
+</SPEC-HIERARCHY>
+"""  # noqa: E501
+
+    specification_xml = ElementTree.fromstring(specification_string)
+    spec_hierarchy = ReqIFSpecHierarchyParser.parse(specification_xml)
+    assert spec_hierarchy.description == "Some & description"
+
+    unparsed = ReqIFSpecHierarchyParser.unparse(spec_hierarchy)
+    assert unparsed.splitlines()[0].lstrip() == (
+        '<SPEC-HIERARCHY DESC="Some &amp; description" IDENTIFIER="LEVEL_1" '
+        'LAST-CHANGE="2015-12-14T02:04:51.856+01:00">'
+    )
+
+
+def test_03_no_desc_is_not_emitted() -> None:
+    specification_string = """\
+<SPEC-HIERARCHY IDENTIFIER="LEVEL_1">
+  <OBJECT>
+    <SPEC-OBJECT-REF>TEST_OBJECT_REF_1</SPEC-OBJECT-REF>
+  </OBJECT>
+</SPEC-HIERARCHY>
+"""
+
+    specification_xml = ElementTree.fromstring(specification_string)
+    spec_hierarchy = ReqIFSpecHierarchyParser.parse(specification_xml)
+    assert spec_hierarchy.description is None
+    assert "DESC" not in ReqIFSpecHierarchyParser.unparse(spec_hierarchy)


### PR DESCRIPTION
ReqIFSpecHierarchy had no field for the optional DESC attribute, so the parser dropped it and the unparser never emitted it. DESC survived only as an entry in the preserved `xml_node`, which forced downstream users to read it off the raw node and monkey-patch the unparser to re-inject it.

Add a `description` field, parse DESC into it, and emit it (HTML-escaped) as the first attribute of <SPEC-HIERARCHY>, matching how SPECIFICATION, SPEC-OBJECT, SPEC-RELATION and the SPEC-*-TYPE elements already handle DESC.