### PR TITLE
feat: keep SPEC-HIERARCHY EDITABLE-ATTS

### DIFF
--- a/reqif/models/reqif_spec_hierarchy.py
+++ b/reqif/models/reqif_spec_hierarchy.py
@@ -1,6 +1,26 @@
 from typing import Any, List, Optional
 
 from reqif.helpers.debug import auto_described
+from reqif.models.reqif_types import SpecObjectAttributeType
+
+
+@auto_described
+class EditableAttributeRef:
+    """One entry of a SPEC-HIERARCHY <EDITABLE-ATTS> element.
+
+    The attribute type is carried alongside the reference because the reference
+    tag names it: ATTRIBUTE-DEFINITION-STRING-REF, -INTEGER-REF, and so on. It
+    cannot be recovered from the identifier alone.
+    """
+
+    def __init__(
+        self,
+        *,
+        attribute_type: SpecObjectAttributeType,
+        definition_ref: str,
+    ):
+        self.attribute_type: SpecObjectAttributeType = attribute_type
+        self.definition_ref: str = definition_ref
 
 
 @auto_described
@@ -13,6 +33,7 @@ class ReqIFSpecHierarchy:  # pylint: disable=too-many-instance-attributes
         level: int,
         children: Optional[List["ReqIFSpecHierarchy"]] = None,
         description: Optional[str] = None,
+        editable_atts: Optional[List[EditableAttributeRef]] = None,
         long_name: Optional[str] = None,
         ref_then_children_order: bool = True,
         last_change: Optional[str] = None,
@@ -34,6 +55,7 @@ class ReqIFSpecHierarchy:  # pylint: disable=too-many-instance-attributes
         # Optional fields
         self.children: Optional[List[ReqIFSpecHierarchy]] = children
         self.description: Optional[str] = description
+        self.editable_atts: Optional[List[EditableAttributeRef]] = editable_atts
         self.long_name: Optional[str] = long_name
         # Not part of REqIF, but helpful for printing the
         # <OBJECT> and <CHILDREN> tags depending on which tool produced the

--- a/reqif/parsers/spec_hierarchy_parser.py
+++ b/reqif/parsers/spec_hierarchy_parser.py
@@ -1,10 +1,23 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
-from reqif.helpers.lxml import lxml_escape_for_html, lxml_is_self_closed_tag
+from reqif.helpers.lxml import (
+    lxml_escape_for_html,
+    lxml_is_comment_node,
+    lxml_is_self_closed_tag,
+)
 from reqif.models.reqif_spec_hierarchy import (
+    EditableAttributeRef,
     ReqIFSpecHierarchy,
 )
+from reqif.models.reqif_types import SpecObjectAttributeType
 from reqif.parsers.alternative_id_parser import AlternativeIDParser
+
+# ATTRIBUTE-DEFINITION-STRING-REF -> STRING, and so on for the other six kinds.
+# Derived from the enum so the two cannot drift apart.
+EDITABLE_ATTS_REF_TAGS: Dict[str, SpecObjectAttributeType] = {
+    f"{attribute_type.get_spec_type_tag()}-REF": attribute_type
+    for attribute_type in SpecObjectAttributeType
+}
 
 
 class ReqIFSpecHierarchyParser:
@@ -36,9 +49,9 @@ class ReqIFSpecHierarchyParser:
             is_table_internal = is_table_internal_str == "true"
 
         # Only the relative order of OBJECT and CHILDREN matters here. Comparing
-        # the whole child list would read any other child, such as the
-        # ALTERNATIVE-ID this commit starts preserving or a comment node, as "not
-        # the OBJECT-then-CHILDREN shape" and silently swap the two on write.
+        # the whole child list would read any other child, such as ALTERNATIVE-ID,
+        # EDITABLE-ATTS or a comment node, as "not the OBJECT-then-CHILDREN shape"
+        # and silently swap the two on write.
         ref_then_children_order = [
             el.tag for el in spec_hierarchy_xml if el.tag in ("OBJECT", "CHILDREN")
         ] == ["OBJECT", "CHILDREN"]
@@ -47,6 +60,22 @@ class ReqIFSpecHierarchyParser:
         spec_object_ref_xml = object_xml.find("SPEC-OBJECT-REF")
 
         spec_object_ref = spec_object_ref_xml.text
+
+        editable_atts: Optional[List[EditableAttributeRef]] = None
+        xml_editable_atts = spec_hierarchy_xml.find("EDITABLE-ATTS")
+        if xml_editable_atts is not None:
+            editable_atts = []
+            for xml_ref in xml_editable_atts:
+                if lxml_is_comment_node(xml_ref):
+                    continue
+                if xml_ref.tag not in EDITABLE_ATTS_REF_TAGS:
+                    raise NotImplementedError(xml_ref.tag)
+                editable_atts.append(
+                    EditableAttributeRef(
+                        attribute_type=EDITABLE_ATTS_REF_TAGS[xml_ref.tag],
+                        definition_ref=xml_ref.text,
+                    )
+                )
 
         spec_hierarchy_children: Optional[List[ReqIFSpecHierarchy]] = None
         xml_spec_hierarchy_children = spec_hierarchy_xml.find("CHILDREN")
@@ -68,6 +97,7 @@ class ReqIFSpecHierarchyParser:
             editable=editable,
             spec_object=spec_object_ref,
             children=spec_hierarchy_children,
+            editable_atts=editable_atts,
             ref_then_children_order=ref_then_children_order,
             level=level,
             is_table_internal=is_table_internal,
@@ -99,6 +129,22 @@ class ReqIFSpecHierarchyParser:
         output += AlternativeIDParser.unparse(
             hierarchy.alternative_id, base_level_str + "  "
         )
+
+        # Emitted before OBJECT and CHILDREN, matching the order the schema
+        # lists SPEC-HIERARCHY's children in. The element is an xsd:all, so the
+        # position carries no meaning, and no existing fixture uses it.
+        if hierarchy.editable_atts is not None:
+            if len(hierarchy.editable_atts) == 0:
+                output += base_level_str + "  <EDITABLE-ATTS/>\n"
+            else:
+                output += base_level_str + "  <EDITABLE-ATTS>\n"
+                for editable_att in hierarchy.editable_atts:
+                    ref_tag = f"{editable_att.attribute_type.get_spec_type_tag()}-REF"
+                    output += (
+                        base_level_str + "    "
+                        f"<{ref_tag}>{editable_att.definition_ref}</{ref_tag}>\n"
+                    )
+                output += base_level_str + "  </EDITABLE-ATTS>\n"
 
         def print_object() -> str:
             object_output = base_level_str + "  <OBJECT>\n"

--- a/tests/unit/reqif/parsers/test_spec_hierarchy.py
+++ b/tests/unit/reqif/parsers/test_spec_hierarchy.py
@@ -1,5 +1,8 @@
 from xml.etree import ElementTree
 
+import pytest
+
+from reqif.models.reqif_types import SpecObjectAttributeType
 from reqif.parsers.spec_hierarchy_parser import (
     ReqIFSpecHierarchyParser,
 )
@@ -44,6 +47,10 @@ def test_01_nominal_case() -> None:
     assert specification_1_1_1.identifier == "LEVEL_1_1_1"
     assert specification_1_1_1.children is None
     assert specification_1_1_1.level == 3
+    assert specification_1.editable_atts is None
+
+    # A SPEC-HIERARCHY without EDITABLE-ATTS must not grow one.
+    assert "EDITABLE-ATTS" not in ReqIFSpecHierarchyParser.unparse(specification_1)
 
 
 def test_02_desc() -> None:
@@ -79,3 +86,103 @@ def test_03_no_desc_is_not_emitted() -> None:
     spec_hierarchy = ReqIFSpecHierarchyParser.parse(specification_xml)
     assert spec_hierarchy.description is None
     assert "DESC" not in ReqIFSpecHierarchyParser.unparse(spec_hierarchy)
+
+
+def test_04_editable_atts() -> None:
+    specification_string = """
+<SPEC-HIERARCHY IDENTIFIER="LEVEL_1">
+  <EDITABLE-ATTS>
+    <ATTRIBUTE-DEFINITION-STRING-REF>DEF_STRING</ATTRIBUTE-DEFINITION-STRING-REF>
+    <ATTRIBUTE-DEFINITION-XHTML-REF>DEF_XHTML</ATTRIBUTE-DEFINITION-XHTML-REF>
+  </EDITABLE-ATTS>
+  <OBJECT>
+    <SPEC-OBJECT-REF>TEST_OBJECT_REF_1</SPEC-OBJECT-REF>
+  </OBJECT>
+</SPEC-HIERARCHY>
+    """  # noqa: E501
+
+    spec_hierarchy = ReqIFSpecHierarchyParser.parse(
+        ElementTree.fromstring(specification_string)
+    )
+
+    assert spec_hierarchy.editable_atts is not None
+    assert [
+        (att.attribute_type, att.definition_ref) for att in spec_hierarchy.editable_atts
+    ] == [
+        (SpecObjectAttributeType.STRING, "DEF_STRING"),
+        (SpecObjectAttributeType.XHTML, "DEF_XHTML"),
+    ]
+
+    # The reference tag names the attribute type, so it has to be reproduced.
+    unparsed = ReqIFSpecHierarchyParser.unparse(spec_hierarchy)
+    assert (
+        "<ATTRIBUTE-DEFINITION-STRING-REF>DEF_STRING</ATTRIBUTE-DEFINITION-STRING-REF>"
+        in unparsed
+    )
+    assert (
+        "<ATTRIBUTE-DEFINITION-XHTML-REF>DEF_XHTML</ATTRIBUTE-DEFINITION-XHTML-REF>"
+        in unparsed
+    )
+    assert unparsed.index("<EDITABLE-ATTS>") < unparsed.index("<OBJECT>")
+
+
+def test_05_editable_atts_does_not_swap_object_and_children() -> None:
+    """An extra child must not be read as "not the OBJECT-then-CHILDREN shape"."""
+    specification_string = """
+<SPEC-HIERARCHY IDENTIFIER="LEVEL_1">
+  <EDITABLE-ATTS>
+    <ATTRIBUTE-DEFINITION-STRING-REF>DEF_STRING</ATTRIBUTE-DEFINITION-STRING-REF>
+  </EDITABLE-ATTS>
+  <OBJECT>
+    <SPEC-OBJECT-REF>TEST_OBJECT_REF_1</SPEC-OBJECT-REF>
+  </OBJECT>
+  <CHILDREN>
+    <SPEC-HIERARCHY IDENTIFIER="LEVEL_1_1">
+      <OBJECT>
+        <SPEC-OBJECT-REF>TEST_OBJECT_REF_1_1</SPEC-OBJECT-REF>
+      </OBJECT>
+    </SPEC-HIERARCHY>
+  </CHILDREN>
+</SPEC-HIERARCHY>
+    """  # noqa: E501
+
+    spec_hierarchy = ReqIFSpecHierarchyParser.parse(
+        ElementTree.fromstring(specification_string)
+    )
+    assert spec_hierarchy.ref_then_children_order is True
+
+    unparsed = ReqIFSpecHierarchyParser.unparse(spec_hierarchy)
+    assert unparsed.index("<OBJECT>") < unparsed.index("<CHILDREN>")
+
+
+def test_06_empty_editable_atts_stays_self_closed() -> None:
+    specification_string = """
+<SPEC-HIERARCHY IDENTIFIER="LEVEL_1">
+  <EDITABLE-ATTS/>
+  <OBJECT>
+    <SPEC-OBJECT-REF>TEST_OBJECT_REF_1</SPEC-OBJECT-REF>
+  </OBJECT>
+</SPEC-HIERARCHY>
+    """  # noqa: E501
+
+    spec_hierarchy = ReqIFSpecHierarchyParser.parse(
+        ElementTree.fromstring(specification_string)
+    )
+    assert spec_hierarchy.editable_atts == []
+    assert "<EDITABLE-ATTS/>" in ReqIFSpecHierarchyParser.unparse(spec_hierarchy)
+
+
+def test_07_unknown_editable_atts_ref_is_rejected() -> None:
+    specification_string = """
+<SPEC-HIERARCHY IDENTIFIER="LEVEL_1">
+  <EDITABLE-ATTS>
+    <SPEC-OBJECT-REF>NOT_AN_ATTRIBUTE_DEFINITION</SPEC-OBJECT-REF>
+  </EDITABLE-ATTS>
+  <OBJECT>
+    <SPEC-OBJECT-REF>TEST_OBJECT_REF_1</SPEC-OBJECT-REF>
+  </OBJECT>
+</SPEC-HIERARCHY>
+    """  # noqa: E501
+
+    with pytest.raises(NotImplementedError):
+        ReqIFSpecHierarchyParser.parse(ElementTree.fromstring(specification_string))


### PR DESCRIPTION
The XSD allows ALTERNATIVE-ID, CHILDREN, EDITABLE-ATTS and OBJECT on SPEC-HIERARCHY, but the parser only looked for OBJECT and CHILDREN, so EDITABLE-ATTS was dropped without even a warning. DOORS and Polarion exports use it to mark per-row editability.

ReqIFSpecHierarchy now carries `editable_atts`. Each entry is an EditableAttributeRef pairing the reference with its SpecObjectAttributeType, because the reference tag names the type
(ATTRIBUTE-DEFINITION-STRING-REF and so on) and it cannot be recovered from the identifier. The tag-to-type mapping is derived from SpecObjectAttributeType rather than written out, so the two cannot drift. An unrecognised child of EDITABLE-ATTS raises NotImplementedError instead of being skipped. An empty EDITABLE-ATTS parses to [] and is written back self-closed, matching how <VALUES/> is handled.

Fixing this exposed a second bug. `ref_then_children_order` compared the whole child list against ["OBJECT", "CHILDREN"], so any additional child made it false and the unparser then emitted CHILDREN before OBJECT. Adding EDITABLE-ATTS to a file was enough to trigger it, and an ALTERNATIVE-ID or a comment node would have done the same. The comparison now looks only at the relative order of OBJECT and CHILDREN.

EDITABLE-ATTS is written before OBJECT and CHILDREN, the order the schema lists them in. SPEC-HIERARCHY is an xsd:all, so the position carries no meaning, and no existing fixture uses the element, so integration output is unchanged.