### PR TITLE
feat: keep ALTERNATIVE-ID on every identified element

### DIFF
--- a/reqif/models/reqif_data_type.py
+++ b/reqif/models/reqif_data_type.py
@@ -13,8 +13,10 @@ class ReqIFDataTypeDefinitionString:
         long_name: Optional[str] = None,
         max_length: Optional[str] = None,
         is_self_closed: bool = True,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name
@@ -39,8 +41,10 @@ class ReqIFDataTypeDefinitionBoolean:
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         is_self_closed: bool = True,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name
@@ -66,8 +70,10 @@ class ReqIFDataTypeDefinitionInteger:
         max_value: Optional[str] = None,
         min_value: Optional[str] = None,
         is_self_closed: bool = True,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name
@@ -88,8 +94,10 @@ class ReqIFDataTypeDefinitionReal:  # pylint: disable=too-many-instance-attribut
         max_value: Optional[str] = None,
         min_value: Optional[str] = None,
         is_self_closed: bool = False,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.accuracy: Optional[int] = accuracy
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
@@ -109,8 +117,10 @@ class ReqIFEnumValue:
         last_change: Optional[str] = None,
         other_content: Optional[str] = None,
         long_name: Optional[str] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.key: Optional[str] = key
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
@@ -135,8 +145,10 @@ class ReqIFDataTypeDefinitionEnumeration:  # pylint: disable=too-many-instance-a
         long_name: Optional[str] = None,
         values: Optional[List[ReqIFEnumValue]] = None,
         is_self_closed: bool = False,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name
@@ -164,8 +176,10 @@ class ReqIFDataTypeDefinitionXHTML:
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         is_self_closed: bool = False,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name
@@ -181,8 +195,10 @@ class ReqIFDataTypeDefinitionDateIdentifier:
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         is_self_closed: bool = True,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name

--- a/reqif/models/reqif_relation_group.py
+++ b/reqif/models/reqif_relation_group.py
@@ -13,8 +13,10 @@ class ReqIFRelationGroup:  # pylint: disable=too-many-instance-attributes
         target_specification_ref: Optional[str] = None,
         spec_relations: Optional[List[str]] = None,
         is_self_closed: bool = True,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name

--- a/reqif/models/reqif_relation_group_type.py
+++ b/reqif/models/reqif_relation_group_type.py
@@ -12,8 +12,10 @@ class ReqIFRelationGroupType:
         long_name: Optional[str] = None,
         is_self_closed: bool = True,
         attribute_definitions: Optional[List[SpecAttributeDefinition]] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name

--- a/reqif/models/reqif_spec_hierarchy.py
+++ b/reqif/models/reqif_spec_hierarchy.py
@@ -19,11 +19,13 @@ class ReqIFSpecHierarchy:  # pylint: disable=too-many-instance-attributes
         is_table_internal: Optional[bool] = False,
         is_self_closed: bool = True,
         xml_node: Optional[Any] = None,
+        alternative_id: Optional[str] = None,
     ):
         assert level >= 0
 
         # Mandatory fields.
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.spec_object: str = spec_object
         # Not part of ReqIF, but helpful to calculate the section depth levels.
         self.level = level

--- a/reqif/models/reqif_spec_object.py
+++ b/reqif/models/reqif_spec_object.py
@@ -34,8 +34,10 @@ class ReqIFSpecObject:  # pylint: disable=too-many-instance-attributes
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         xml_node: Optional[Any] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.attributes: List[SpecObjectAttribute] = attributes
         self.spec_object_type: str = spec_object_type
 

--- a/reqif/models/reqif_spec_object_type.py
+++ b/reqif/models/reqif_spec_object_type.py
@@ -23,9 +23,11 @@ class SpecAttributeDefinition:  # pylint: disable=too-many-instance-attributes
         default_value_definition_ref: Optional[str] = None,
         default_value: Union[None, DefaultValueEmptySelfClosedTag, str] = None,
         multi_valued: Optional[bool] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.attribute_type: SpecObjectAttributeType = attribute_type
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.datatype_definition: str = datatype_definition
 
         self.xml_node: Optional[Any] = xml_node
@@ -67,8 +69,10 @@ class ReqIFSpecObjectType:
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         attribute_definitions: Optional[List[SpecAttributeDefinition]] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
 
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change

--- a/reqif/models/reqif_spec_relation.py
+++ b/reqif/models/reqif_spec_relation.py
@@ -17,8 +17,10 @@ class ReqIFSpecRelation:  # pylint: disable=too-many-instance-attributes
         last_change: Optional[str] = None,
         long_name: Optional[str] = None,
         values_attribute: Optional[SpecObjectAttribute] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.relation_type_ref: str = relation_type_ref
         self.source: str = source
         self.target: str = target

--- a/reqif/models/reqif_spec_relation_type.py
+++ b/reqif/models/reqif_spec_relation_type.py
@@ -12,8 +12,10 @@ class ReqIFSpecRelationType:
         long_name: Optional[str] = None,
         is_self_closed: bool = True,
         attribute_definitions: Optional[List[SpecAttributeDefinition]] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name

--- a/reqif/models/reqif_specification.py
+++ b/reqif/models/reqif_specification.py
@@ -19,8 +19,10 @@ class ReqIFSpecification:  # pylint: disable=too-many-instance-attributes
         specification_type: Optional[str] = None,
         children: Optional[List[ReqIFSpecHierarchy]] = None,
         xml_node: Optional[Any] = None,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change
         self.long_name: Optional[str] = long_name

--- a/reqif/models/reqif_specification_type.py
+++ b/reqif/models/reqif_specification_type.py
@@ -15,8 +15,10 @@ class ReqIFSpecificationType:
         spec_attributes: Optional[List[SpecAttributeDefinition]] = None,
         spec_attribute_map: Optional[Dict[str, str]] = None,
         is_self_closed: bool = False,
+        alternative_id: Optional[str] = None,
     ):
         self.identifier: str = identifier
+        self.alternative_id: Optional[str] = alternative_id
 
         self.description: Optional[str] = description
         self.last_change: Optional[str] = last_change

--- a/reqif/parsers/alternative_id_parser.py
+++ b/reqif/parsers/alternative_id_parser.py
@@ -1,0 +1,38 @@
+from typing import Any, Optional
+
+
+class AlternativeIDParser:
+    """ALTERNATIVE-ID, which the schema allows on every identified element.
+
+    The element is a wrapper around a single self-closed
+    <ALTERNATIVE-ID IDENTIFIER="..."/>, so its whole content is one identifier:
+
+        <ALTERNATIVE-ID>
+          <ALTERNATIVE-ID IDENTIFIER="ALT_ID"/>
+        </ALTERNATIVE-ID>
+    """
+
+    @staticmethod
+    def parse(xml_node: Any) -> Optional[str]:
+        xml_wrapper = xml_node.find("ALTERNATIVE-ID")
+        if xml_wrapper is None:
+            return None
+        xml_inner = xml_wrapper.find("ALTERNATIVE-ID")
+        if xml_inner is None:
+            # The schema permits an empty wrapper. It carries no identifier, so
+            # there is nothing to model and the empty element is not preserved.
+            return None
+        # Bound to a typed local: xml nodes are Any, and returning that directly
+        # trips mypy --strict's no-any-return.
+        identifier: str = xml_inner.attrib["IDENTIFIER"]
+        return identifier
+
+    @staticmethod
+    def unparse(alternative_id: Optional[str], indent: str) -> str:
+        if alternative_id is None:
+            return ""
+        return (
+            f"{indent}<ALTERNATIVE-ID>\n"
+            f'{indent}  <ALTERNATIVE-ID IDENTIFIER="{alternative_id}"/>\n'
+            f"{indent}</ALTERNATIVE-ID>\n"
+        )

--- a/reqif/parsers/attribute_definition_parser.py
+++ b/reqif/parsers/attribute_definition_parser.py
@@ -10,6 +10,7 @@ from reqif.models.reqif_spec_object_type import (
     SpecAttributeDefinition,
 )
 from reqif.models.reqif_types import SpecObjectAttributeType
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 
 
 class AttributeDefinitionParser:
@@ -233,6 +234,7 @@ class AttributeDefinitionParser:
             else:
                 raise NotImplementedError(attribute_definition) from None
             attribute_definition = SpecAttributeDefinition(
+                alternative_id=AlternativeIDParser.parse(attribute_definition),
                 xml_node=attribute_definition,
                 attribute_type=attribute_type,
                 description=description,
@@ -311,6 +313,7 @@ class AttributeDefinitionParser:
                 raise NotImplementedError
 
         return SpecAttributeDefinition(
+            alternative_id=AlternativeIDParser.parse(xml_attribute_definition),
             xml_node=xml_attribute_definition,
             attribute_type=SpecObjectAttributeType.XHTML,
             description=description,
@@ -357,9 +360,13 @@ class AttributeDefinitionParser:
         if attribute.xml_node is not None:
             children_tags = list(map(lambda el: el.tag, list(attribute.xml_node)))
         else:
-            children_tags = ["DEFAULT-VALUE", "TYPE"]
+            children_tags = ["ALTERNATIVE-ID", "DEFAULT-VALUE", "TYPE"]
         for tag in children_tags:
-            if tag == "DEFAULT-VALUE":
+            if tag == "ALTERNATIVE-ID":
+                output += AlternativeIDParser.unparse(
+                    attribute.alternative_id, "              "
+                )
+            elif tag == "DEFAULT-VALUE":
                 attribute_default_value = attribute.default_value
                 if attribute_default_value is not None:
                     unparsed_default_value = (

--- a/reqif/parsers/data_type_parser.py
+++ b/reqif/parsers/data_type_parser.py
@@ -13,6 +13,7 @@ from reqif.models.reqif_data_type import (
     ReqIFDataTypeDefinitionXHTML,
     ReqIFEnumValue,
 )
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 
 
 class DataTypeParser:
@@ -84,6 +85,9 @@ class DataTypeParser:
                         embedded_value_other_content = None
                     values.append(
                         ReqIFEnumValue(
+                            alternative_id=AlternativeIDParser.parse(
+                                xml_specified_value
+                            ),
                             description=specified_value_description,
                             identifier=specified_value_identifier,
                             last_change=specified_value_last_change,
@@ -93,6 +97,7 @@ class DataTypeParser:
                         )
                     )
             return ReqIFDataTypeDefinitionEnumeration(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 description=description,
                 identifier=identifier,
@@ -107,6 +112,7 @@ class DataTypeParser:
             )
 
             return ReqIFDataTypeDefinitionString(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 description=description,
                 identifier=identifier,
@@ -120,6 +126,7 @@ class DataTypeParser:
             min_value = attributes["MIN"] if "MIN" in attributes else None
 
             return ReqIFDataTypeDefinitionInteger(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 description=description,
                 identifier=identifier,
@@ -135,6 +142,7 @@ class DataTypeParser:
             min_value = attributes["MIN"] if "MIN" in attributes else None
 
             return ReqIFDataTypeDefinitionReal(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 accuracy=accuracy,
                 description=description,
@@ -147,6 +155,7 @@ class DataTypeParser:
 
         if data_type_xml.tag == "DATATYPE-DEFINITION-XHTML":
             return ReqIFDataTypeDefinitionXHTML(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 description=description,
                 identifier=identifier,
@@ -156,6 +165,7 @@ class DataTypeParser:
 
         if data_type_xml.tag == "DATATYPE-DEFINITION-DATE":
             return ReqIFDataTypeDefinitionDateIdentifier(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 description=description,
                 identifier=identifier,
@@ -165,6 +175,7 @@ class DataTypeParser:
 
         if data_type_xml.tag == "DATATYPE-DEFINITION-BOOLEAN":
             return ReqIFDataTypeDefinitionBoolean(
+                alternative_id=AlternativeIDParser.parse(data_type_xml),
                 is_self_closed=is_self_closed,
                 description=description,
                 identifier=identifier,
@@ -195,10 +206,16 @@ class DataTypeParser:
                 output += f' LONG-NAME="{escaped_long_name}"'
             if data_type_definition.max_length:
                 output += f' MAX-LENGTH="{data_type_definition.max_length}"'
-            if data_type_definition.is_self_closed:
+            if (
+                data_type_definition.is_self_closed
+                and data_type_definition.alternative_id is None
+            ):
                 output += "/>\n"
             else:
                 output += ">\n"
+                output += AlternativeIDParser.unparse(
+                    data_type_definition.alternative_id, "          "
+                )
                 output += "        </DATATYPE-DEFINITION-STRING>\n"
             return output
         if isinstance(data_type_definition, ReqIFDataTypeDefinitionBoolean):
@@ -214,10 +231,16 @@ class DataTypeParser:
             if data_type_definition.long_name is not None:
                 escaped_long_name = lxml_escape_for_html(data_type_definition.long_name)
                 output += f' LONG-NAME="{escaped_long_name}"'
-            if data_type_definition.is_self_closed:
+            if (
+                data_type_definition.is_self_closed
+                and data_type_definition.alternative_id is None
+            ):
                 output += "/>\n"
             else:
                 output += ">\n"
+                output += AlternativeIDParser.unparse(
+                    data_type_definition.alternative_id, "          "
+                )
                 output += "        </DATATYPE-DEFINITION-BOOLEAN>\n"
             return output
         if isinstance(data_type_definition, ReqIFDataTypeDefinitionInteger):
@@ -236,10 +259,16 @@ class DataTypeParser:
                 output += f' MAX="{data_type_definition.max_value}"'
             if data_type_definition.min_value is not None:
                 output += f' MIN="{data_type_definition.min_value}"'
-            if data_type_definition.is_self_closed:
+            if (
+                data_type_definition.is_self_closed
+                and data_type_definition.alternative_id is None
+            ):
                 output += "/>\n"
             else:
                 output += ">\n"
+                output += AlternativeIDParser.unparse(
+                    data_type_definition.alternative_id, "          "
+                )
                 output += "        </DATATYPE-DEFINITION-INTEGER>\n"
             return output
         if isinstance(data_type_definition, ReqIFDataTypeDefinitionReal):
@@ -265,7 +294,16 @@ class DataTypeParser:
             if data_type_definition.min_value is not None:
                 output += f' MIN="{data_type_definition.min_value}"'
 
-            output += "/>\n"
+            # Unlike the other branches this one has no is_self_closed check, so
+            # an alternative_id is the only thing that can force the open form.
+            if data_type_definition.alternative_id is None:
+                output += "/>\n"
+            else:
+                output += ">\n"
+                output += AlternativeIDParser.unparse(
+                    data_type_definition.alternative_id, "          "
+                )
+                output += "        </DATATYPE-DEFINITION-REAL>\n"
             return output
         if isinstance(data_type_definition, ReqIFDataTypeDefinitionEnumeration):
             output = "        <DATATYPE-DEFINITION-ENUMERATION"
@@ -280,10 +318,16 @@ class DataTypeParser:
             if data_type_definition.long_name is not None:
                 escaped_long_name = lxml_escape_for_html(data_type_definition.long_name)
                 output += f' LONG-NAME="{escaped_long_name}"'
-            if data_type_definition.is_self_closed:
+            if (
+                data_type_definition.is_self_closed
+                and data_type_definition.alternative_id is None
+            ):
                 output += "/>\n"
             else:
                 output += ">\n"
+            output += AlternativeIDParser.unparse(
+                data_type_definition.alternative_id, "          "
+            )
 
             if data_type_definition.values is not None:
                 output += "          <SPECIFIED-VALUES>\n"
@@ -299,6 +343,9 @@ class DataTypeParser:
                         escaped_long_name = lxml_escape_for_html(value.long_name)
                         output += f' LONG-NAME="{escaped_long_name}"'
                     output += ">\n"
+                    output += AlternativeIDParser.unparse(
+                        value.alternative_id, "              "
+                    )
 
                     if value.key is not None:
                         output += "              <PROPERTIES>\n"
@@ -328,10 +375,16 @@ class DataTypeParser:
                 output += f' LAST-CHANGE="{data_type_definition.last_change}"'
             if data_type_definition.long_name:
                 output += f' LONG-NAME="{data_type_definition.long_name}"'
-            if data_type_definition.is_self_closed:
+            if (
+                data_type_definition.is_self_closed
+                and data_type_definition.alternative_id is None
+            ):
                 output += "/>\n"
             else:
                 output += ">\n"
+                output += AlternativeIDParser.unparse(
+                    data_type_definition.alternative_id, "          "
+                )
                 output += "        </DATATYPE-DEFINITION-DATE>\n"
             return output
         if isinstance(data_type_definition, ReqIFDataTypeDefinitionXHTML):
@@ -348,10 +401,16 @@ class DataTypeParser:
             if data_type_definition.long_name is not None:
                 escaped_long_name = lxml_escape_for_html(data_type_definition.long_name)
                 output += f' LONG-NAME="{escaped_long_name}"'
-            if data_type_definition.is_self_closed:
+            if (
+                data_type_definition.is_self_closed
+                and data_type_definition.alternative_id is None
+            ):
                 output += "/>\n"
             else:
                 output += ">\n"
+                output += AlternativeIDParser.unparse(
+                    data_type_definition.alternative_id, "          "
+                )
                 output += "        </DATATYPE-DEFINITION-XHTML>\n"
             return output
 

--- a/reqif/parsers/relation_group_parser.py
+++ b/reqif/parsers/relation_group_parser.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from reqif.models.reqif_relation_group import ReqIFRelationGroup
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 
 
 class ReqIFRelationGroupParser:
@@ -58,6 +59,7 @@ class ReqIFRelationGroupParser:
                 target_specification_ref = xml_type_ref.text
 
         return ReqIFRelationGroup(
+            alternative_id=AlternativeIDParser.parse(xml_relation_group),
             identifier=identifier,
             description=description,
             last_change=last_change,
@@ -84,6 +86,10 @@ class ReqIFRelationGroupParser:
         if relation_group.long_name:
             output += f' LONG-NAME="{relation_group.long_name}"'
         output += ">\n"
+
+        output += AlternativeIDParser.unparse(
+            relation_group.alternative_id, "          "
+        )
 
         if relation_group.spec_relations is not None:
             output += "          <SPEC-RELATIONS>\n"

--- a/reqif/parsers/spec_hierarchy_parser.py
+++ b/reqif/parsers/spec_hierarchy_parser.py
@@ -4,6 +4,7 @@ from reqif.helpers.lxml import lxml_is_self_closed_tag
 from reqif.models.reqif_spec_hierarchy import (
     ReqIFSpecHierarchy,
 )
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 
 
 class ReqIFSpecHierarchyParser:
@@ -31,9 +32,13 @@ class ReqIFSpecHierarchyParser:
             is_table_internal_str = attributes["IS-TABLE-INTERNAL"]
             is_table_internal = is_table_internal_str == "true"
 
-        ref_then_children_order = list(
-            map(lambda el: el.tag, list(spec_hierarchy_xml))
-        ) == ["OBJECT", "CHILDREN"]
+        # Only the relative order of OBJECT and CHILDREN matters here. Comparing
+        # the whole child list would read any other child, such as the
+        # ALTERNATIVE-ID this commit starts preserving or a comment node, as "not
+        # the OBJECT-then-CHILDREN shape" and silently swap the two on write.
+        ref_then_children_order = [
+            el.tag for el in spec_hierarchy_xml if el.tag in ("OBJECT", "CHILDREN")
+        ] == ["OBJECT", "CHILDREN"]
 
         object_xml = spec_hierarchy_xml.find("OBJECT")
         spec_object_ref_xml = object_xml.find("SPEC-OBJECT-REF")
@@ -52,6 +57,7 @@ class ReqIFSpecHierarchyParser:
                 )
                 spec_hierarchy_children.append(child_spec_hierarchy)
         return ReqIFSpecHierarchy(
+            alternative_id=AlternativeIDParser.parse(spec_hierarchy_xml),
             identifier=identifier,
             last_change=last_change,
             long_name=long_name,
@@ -83,6 +89,10 @@ class ReqIFSpecHierarchyParser:
         if hierarchy.long_name:
             output += f' LONG-NAME="{hierarchy.long_name}"'
         output += ">\n"
+
+        output += AlternativeIDParser.unparse(
+            hierarchy.alternative_id, base_level_str + "  "
+        )
 
         def print_object() -> str:
             object_output = base_level_str + "  <OBJECT>\n"

--- a/reqif/parsers/spec_object_parser.py
+++ b/reqif/parsers/spec_object_parser.py
@@ -8,6 +8,7 @@ from reqif.models.reqif_spec_object import (
 from reqif.parsers.attribute_value_parser import AttributeValueParser
 
 logger = logging.getLogger(__name__)
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 
 
 class SpecObjectParser:
@@ -40,6 +41,7 @@ class SpecObjectParser:
         )
 
         return ReqIFSpecObject(
+            alternative_id=AlternativeIDParser.parse(spec_object_xml),
             xml_node=spec_object_xml,
             description=spec_object_description,
             identifier=identifier,
@@ -70,10 +72,14 @@ class SpecObjectParser:
             assert "VALUES" in children_tags
             assert "TYPE" in children_tags
         else:
-            children_tags = ["VALUES", "TYPE"]
+            children_tags = ["ALTERNATIVE-ID", "VALUES", "TYPE"]
 
         for child_tag in children_tags:
-            if child_tag == "VALUES":
+            if child_tag == "ALTERNATIVE-ID":
+                output += AlternativeIDParser.unparse(
+                    spec_object.alternative_id, "          "
+                )
+            elif child_tag == "VALUES":
                 output += AttributeValueParser.unparse_attribute_values(
                     spec_object.attributes
                 )

--- a/reqif/parsers/spec_relation_parser.py
+++ b/reqif/parsers/spec_relation_parser.py
@@ -7,6 +7,7 @@ from reqif.models.reqif_spec_relation import (
     ReqIFSpecRelation,
 )
 from reqif.models.reqif_types import SpecObjectAttributeType
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 from reqif.parsers.attribute_value_parser import AttributeValueParser
 
 
@@ -85,6 +86,7 @@ class SpecRelationParser:
                 break
 
         spec_relation = ReqIFSpecRelation(
+            alternative_id=AlternativeIDParser.parse(xml_spec_relation),
             xml_node=xml_spec_relation,
             description=description,
             identifier=identifier,
@@ -113,9 +115,13 @@ class SpecRelationParser:
         if spec_relation.xml_node is not None:
             children_tags = list(map(lambda el: el.tag, list(spec_relation.xml_node)))
         else:
-            children_tags = ["TYPE", "SOURCE", "TARGET", "VALUES"]
+            children_tags = ["ALTERNATIVE-ID", "TYPE", "SOURCE", "TARGET", "VALUES"]
         for tag in children_tags:
-            if tag == "TYPE":
+            if tag == "ALTERNATIVE-ID":
+                output += AlternativeIDParser.unparse(
+                    spec_relation.alternative_id, "          "
+                )
+            elif tag == "TYPE":
                 output += SpecRelationParser._unparse_spec_relation_type(spec_relation)
             elif tag == "SOURCE":
                 output += SpecRelationParser._unparse_spec_relation_source(

--- a/reqif/parsers/spec_types/relation_group_type_parser.py
+++ b/reqif/parsers/spec_types/relation_group_type_parser.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from reqif.helpers.lxml import lxml_is_self_closed_tag
 from reqif.models.reqif_relation_group_type import ReqIFRelationGroupType
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
@@ -37,6 +38,7 @@ class RelationGroupTypeParser:
         )
 
         return ReqIFRelationGroupType(
+            alternative_id=AlternativeIDParser.parse(xml_spec_relation_type_xml),
             is_self_closed=is_self_closed,
             description=description,
             identifier=identifier,
@@ -59,11 +61,15 @@ class RelationGroupTypeParser:
             spec_relation_type.attribute_definitions is not None
             and len(spec_relation_type.attribute_definitions) > 0
         )
-        if spec_relation_type.is_self_closed and not has_attributes:
+        has_children = has_attributes or spec_relation_type.alternative_id is not None
+        if spec_relation_type.is_self_closed and not has_children:
             output += "/>\n"
             return output
 
         output += ">\n"
+        output += AlternativeIDParser.unparse(
+            spec_relation_type.alternative_id, "          "
+        )
 
         if spec_relation_type.attribute_definitions is not None:
             output += "          <SPEC-ATTRIBUTES>\n"

--- a/reqif/parsers/spec_types/spec_object_type_parser.py
+++ b/reqif/parsers/spec_types/spec_object_type_parser.py
@@ -4,6 +4,7 @@ from reqif.helpers.lxml import lxml_escape_for_html
 from reqif.models.reqif_spec_object_type import (
     ReqIFSpecObjectType,
 )
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
@@ -32,6 +33,7 @@ class SpecObjectTypeParser:
         )
 
         return ReqIFSpecObjectType(
+            alternative_id=AlternativeIDParser.parse(spec_object_type_xml),
             description=spec_description,
             identifier=spec_type_id,
             last_change=spec_last_change,
@@ -53,6 +55,8 @@ class SpecObjectTypeParser:
             escaped_long_name = lxml_escape_for_html(spec_type.long_name)
             output += f' LONG-NAME="{escaped_long_name}"'
         output += ">\n"
+
+        output += AlternativeIDParser.unparse(spec_type.alternative_id, "          ")
 
         if spec_type.attribute_definitions is not None:
             output += "          <SPEC-ATTRIBUTES>\n"

--- a/reqif/parsers/spec_types/spec_relation_type_parser.py
+++ b/reqif/parsers/spec_types/spec_relation_type_parser.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from reqif.helpers.lxml import lxml_is_self_closed_tag
 from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
@@ -34,6 +35,7 @@ class SpecRelationTypeParser:
         )
 
         return ReqIFSpecRelationType(
+            alternative_id=AlternativeIDParser.parse(xml_spec_relation_type_xml),
             is_self_closed=is_self_closed,
             description=description,
             identifier=identifier,
@@ -56,11 +58,15 @@ class SpecRelationTypeParser:
             spec_relation_type.attribute_definitions is not None
             and len(spec_relation_type.attribute_definitions) > 0
         )
-        if spec_relation_type.is_self_closed and not has_attributes:
+        has_children = has_attributes or spec_relation_type.alternative_id is not None
+        if spec_relation_type.is_self_closed and not has_children:
             output += "/>\n"
             return output
 
         output += ">\n"
+        output += AlternativeIDParser.unparse(
+            spec_relation_type.alternative_id, "          "
+        )
 
         if spec_relation_type.attribute_definitions is not None:
             output += "          <SPEC-ATTRIBUTES>\n"

--- a/reqif/parsers/spec_types/specification_type_parser.py
+++ b/reqif/parsers/spec_types/specification_type_parser.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional
 
 from reqif.helpers.lxml import lxml_is_self_closed_tag
 from reqif.models.reqif_specification_type import ReqIFSpecificationType
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 from reqif.parsers.attribute_definition_parser import AttributeDefinitionParser
 
 
@@ -44,6 +45,7 @@ class SpecificationTypeParser:
                 )
 
         return ReqIFSpecificationType(
+            alternative_id=AlternativeIDParser.parse(specification_type_xml),
             description=description,
             identifier=spec_type_id,
             last_change=spec_last_change,
@@ -70,11 +72,13 @@ class SpecificationTypeParser:
         has_attributes = (
             spec_type.spec_attributes is not None and len(spec_type.spec_attributes) > 0
         )
-        if spec_type.is_self_closed and not has_attributes:
+        has_children = has_attributes or spec_type.alternative_id is not None
+        if spec_type.is_self_closed and not has_children:
             output += "/>\n"
             return output
         else:
             output += ">\n"
+        output += AlternativeIDParser.unparse(spec_type.alternative_id, "          ")
 
         if spec_type.spec_attributes is not None:
             output += "          <SPEC-ATTRIBUTES>\n"

--- a/reqif/parsers/specification_parser.py
+++ b/reqif/parsers/specification_parser.py
@@ -5,6 +5,7 @@ from reqif.models.reqif_spec_object import SpecObjectAttribute
 from reqif.models.reqif_specification import (
     ReqIFSpecification,
 )
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
 from reqif.parsers.attribute_value_parser import AttributeValueParser
 from reqif.parsers.spec_hierarchy_parser import (
     ReqIFSpecHierarchyParser,
@@ -67,6 +68,7 @@ class ReqIFSpecificationParser:
         )
 
         return ReqIFSpecification(
+            alternative_id=AlternativeIDParser.parse(specification_xml),
             xml_node=specification_xml,
             description=description,
             identifier=identifier,
@@ -99,10 +101,14 @@ class ReqIFSpecificationParser:
         if specification.xml_node is not None:
             children_tags = list(map(lambda el: el.tag, list(specification.xml_node)))
         else:
-            children_tags = ["TYPE", "CHILDREN", "VALUES"]
+            children_tags = ["ALTERNATIVE-ID", "TYPE", "CHILDREN", "VALUES"]
 
         for tag in children_tags:
-            if tag == "TYPE":
+            if tag == "ALTERNATIVE-ID":
+                output += AlternativeIDParser.unparse(
+                    specification.alternative_id, "          "
+                )
+            elif tag == "TYPE":
                 if specification.specification_type:
                     output += ReqIFSpecificationParser._unparse_specification_type(
                         specification

--- a/tests/unit/reqif/parsers/test_alternative_id_parser.py
+++ b/tests/unit/reqif/parsers/test_alternative_id_parser.py
@@ -1,0 +1,97 @@
+from xml.etree import ElementTree
+
+from reqif.models.reqif_data_type import ReqIFDataTypeDefinitionString
+from reqif.models.reqif_spec_relation_type import ReqIFSpecRelationType
+from reqif.parsers.alternative_id_parser import AlternativeIDParser
+from reqif.parsers.data_type_parser import DataTypeParser
+from reqif.parsers.spec_types.spec_relation_type_parser import (
+    SpecRelationTypeParser,
+)
+
+
+def test_01_parse_returns_the_inner_identifier() -> None:
+    xml = ElementTree.fromstring(
+        """
+<SPEC-OBJECT IDENTIFIER="SO1">
+  <ALTERNATIVE-ID>
+    <ALTERNATIVE-ID IDENTIFIER="ALT_SO1"/>
+  </ALTERNATIVE-ID>
+</SPEC-OBJECT>
+"""
+    )
+    assert AlternativeIDParser.parse(xml) == "ALT_SO1"
+
+
+def test_02_absent_and_empty_wrapper_both_parse_to_none() -> None:
+    without = ElementTree.fromstring('<SPEC-OBJECT IDENTIFIER="SO1"/>')
+    assert AlternativeIDParser.parse(without) is None
+
+    # The schema permits an empty wrapper. It holds no identifier, so there is
+    # nothing to model and the element is not preserved.
+    empty = ElementTree.fromstring(
+        '<SPEC-OBJECT IDENTIFIER="SO1"><ALTERNATIVE-ID/></SPEC-OBJECT>'
+    )
+    assert AlternativeIDParser.parse(empty) is None
+
+
+def test_03_unparse_round_trips_the_nested_shape() -> None:
+    assert AlternativeIDParser.unparse(None, "  ") == ""
+    assert AlternativeIDParser.unparse("ALT_SO1", "  ") == (
+        "  <ALTERNATIVE-ID>\n"
+        '    <ALTERNATIVE-ID IDENTIFIER="ALT_SO1"/>\n'
+        "  </ALTERNATIVE-ID>\n"
+    )
+
+
+def test_04_self_closed_data_type_switches_to_the_open_form() -> None:
+    """A self-closed element cannot host a child, so an alternative_id has to
+    force the open form or it would be dropped on write."""
+    data_type = ReqIFDataTypeDefinitionString(
+        identifier="D1", is_self_closed=True, alternative_id="ALT_D1"
+    )
+    output = DataTypeParser.unparse(data_type)
+    assert "ALT_D1" in output
+    assert "<DATATYPE-DEFINITION-STRING/>" not in output
+    assert "</DATATYPE-DEFINITION-STRING>" in output
+
+    # Without one, the self-closed form is still preserved.
+    plain = ReqIFDataTypeDefinitionString(identifier="D1", is_self_closed=True)
+    assert "<DATATYPE-DEFINITION-STRING" in DataTypeParser.unparse(plain)
+    assert "/>" in DataTypeParser.unparse(plain)
+
+
+def test_05_self_closed_spec_relation_type_switches_to_the_open_form() -> None:
+    spec_relation_type = ReqIFSpecRelationType(
+        identifier="T1", is_self_closed=True, alternative_id="ALT_T1"
+    )
+    output = SpecRelationTypeParser.unparse(spec_relation_type)
+    assert "ALT_T1" in output
+    assert "</SPEC-RELATION-TYPE>" in output
+
+
+def test_06_alternative_id_does_not_swap_object_and_children() -> None:
+    """ALTERNATIVE-ID is an extra SPEC-HIERARCHY child, and the OBJECT/CHILDREN
+    order flag used to compare the whole child list, so preserving it would
+    otherwise reverse those two on write."""
+    from reqif.parsers.spec_hierarchy_parser import ReqIFSpecHierarchyParser
+
+    spec_hierarchy = ReqIFSpecHierarchyParser.parse(
+        ElementTree.fromstring(
+            """
+<SPEC-HIERARCHY IDENTIFIER="L1">
+  <ALTERNATIVE-ID><ALTERNATIVE-ID IDENTIFIER="ALT_L1"/></ALTERNATIVE-ID>
+  <OBJECT><SPEC-OBJECT-REF>A</SPEC-OBJECT-REF></OBJECT>
+  <CHILDREN>
+    <SPEC-HIERARCHY IDENTIFIER="L1_1">
+      <OBJECT><SPEC-OBJECT-REF>B</SPEC-OBJECT-REF></OBJECT>
+    </SPEC-HIERARCHY>
+  </CHILDREN>
+</SPEC-HIERARCHY>
+"""
+        )
+    )
+    assert spec_hierarchy.alternative_id == "ALT_L1"
+    assert spec_hierarchy.ref_then_children_order is True
+
+    unparsed = ReqIFSpecHierarchyParser.unparse(spec_hierarchy)
+    assert unparsed.index("<OBJECT>") < unparsed.index("<CHILDREN>")


### PR DESCRIPTION
The XSD allows ALTERNATIVE-ID on 24 element types, but the string appeared nowhere in the library. It was dropped on read and never written.

How it failed depended on the element. SPEC-OBJECT logged "Unknown child tag" and carried on. SPEC-HIERARCHY, the SPEC-*-TYPEs and the datatypes dropped it silently, because those parsers only look for the children they know. On SPEC-RELATION and on the ATTRIBUTE-DEFINITION-* elements it was worse than data loss: their unparsers raise NotImplementedError on an unrecognised child tag, so writing a parsed file back failed outright.

The element is a wrapper around a single self-closed <ALTERNATIVE-ID IDENTIFIER="..."/>, so its whole content is one identifier. AlternativeIDParser reads and writes that shape, and every identified model now carries `alternative_id`. The parameter is added at the end of each __init__ so positional callers are unaffected.

Two things needed care on the write side:

Elements that short-circuit to a self-closed tag would drop the child. The six datatypes, DATATYPE-DEFINITION-REAL (which self-closes unconditionally, with no is_self_closed check at all), and the three SPEC-*-TYPEs now take the open form when there is an alternative_id to emit.

Parsers that iterate the source child order (SPEC-OBJECT, SPECIFICATION, SPEC-RELATION, ATTRIBUTE-DEFINITION-*) gained an ALTERNATIVE-ID branch, so the element keeps its original position. The rest emit it first, which is where the schema lists it. Every one of these is an xsd:all, so the position carries no meaning.

An empty <ALTERNATIVE-ID/> wrapper is legal and holds no identifier. There is nothing to model, so it parses to None and is not preserved.

Verified by adding the element to every kind that allows one across three fixtures and diffing a passthrough: all preserved, output byte-identical. The one existing fixture that carries a real ALTERNATIVE-ID (performance/TC4000, on a SPEC-OBJECT) now round-trips it. No fixture in the lit suite uses the element, so integration output is unchanged.